### PR TITLE
fix: handle Windows npx spawn EINVAL

### DIFF
--- a/bin/lib/platform.js
+++ b/bin/lib/platform.js
@@ -37,6 +37,14 @@ export function resolveBin(name) {
  * spawn() wrapper that works for npm/npx/any PATH-resolved exe on Windows.
  */
 export function spawnBin(name, args, opts = {}) {
+  if (isWin) {
+    // Node 24 on Windows can throw EINVAL when spawning PATH-resolved .cmd
+    // shims directly with piped stdio. Routing through cmd.exe avoids that.
+    return spawn("cmd.exe", ["/d", "/s", "/c", `${name} ${args.join(" ")}`], {
+      windowsHide: true,
+      ...opts,
+    });
+  }
   return spawn(resolveBin(name), args, { windowsHide: true, ...opts });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ima2": "bin/ima2.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ai-sdk/gateway": {


### PR DESCRIPTION
## Summary
- fix `spawn EINVAL` when launching PATH-resolved commands on Windows
- route Windows `spawnBin()` calls through `cmd.exe`
- sync lockfile engine metadata with the current package setting (`node >=20`)

## Validation
- `npm test`
- `npm run build`
- verified `/api/health` responds after server startup on Windows
