### PR TITLE
Prevent API cache validation 304 responses

### DIFF
--- a/lib/apiCachePolicy.ts
+++ b/lib/apiCachePolicy.ts
@@ -1,0 +1,11 @@
+import type { Express, NextFunction, Request, Response } from "express";
+
+export function setApiNoStoreHeaders(_req: Request, res: Response, next: NextFunction) {
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+  next();
+}
+
+export function configureApiCachePolicy(app: Express) {
+  app.set("etag", false);
+  app.use("/api", setApiNoStoreHeaders);
+}

--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ import { migrateGeneratedStorage } from "./lib/storageMigration.js";
 import { purgeStaleJobs } from "./lib/inflight.js";
 import { configureLogger } from "./lib/logger.js";
 import { createRequestLogger } from "./lib/requestLogger.js";
+import { configureApiCachePolicy } from "./lib/apiCachePolicy.js";
 import { configureRoutes } from "./routes/index.js";
 import { config } from "./config.js";
 import { getServerPort, listenWithPortFallback } from "./lib/runtimePorts.js";
@@ -79,6 +80,7 @@ function setUiStaticHeaders(res: Response, filePath: string) {
 
 export function buildApp(ctx: RuntimeContext) {
   const app = express();
+  configureApiCachePolicy(app);
   configureLogger({ level: ctx.config.log.level });
   app.use(createRequestLogger());
   app.use(express.json({ limit: ctx.config.server.bodyLimit }));

--- a/tests/api-cache-policy.test.ts
+++ b/tests/api-cache-policy.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { request } from "node:http";
+import { configureApiCachePolicy } from "../lib/apiCachePolicy.ts";
+
+type HitOptions = {
+  headers?: Record<string, string>;
+  path?: string;
+};
+
+type HitResult = {
+  body: unknown;
+  headers: import("node:http").IncomingHttpHeaders;
+  status: number | undefined;
+};
+
+async function hit(app: express.Express, { headers = {}, path = "/api/history" }: HitOptions = {}) {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const port = (server.address() as import("node:net").AddressInfo).port;
+  try {
+    return await new Promise<HitResult>((resolve, reject) => {
+      const req = request({ hostname: "127.0.0.1", port, path, headers }, (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          raw += chunk;
+        });
+        res.on("end", () => {
+          resolve({
+            body: raw ? JSON.parse(raw) : null,
+            headers: res.headers,
+            status: res.statusCode,
+          });
+        });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test("API JSON responses use no-store and do not return 304 for conditional requests", async () => {
+  const app = express();
+  configureApiCachePolicy(app);
+  app.get("/api/history", (_req, res) => {
+    res.json({ items: [], nextCursor: null, total: 0 });
+  });
+
+  const first = await hit(app);
+  assert.equal(first.status, 200);
+  assert.equal(first.headers["cache-control"], "no-store, max-age=0");
+  assert.equal(first.headers.etag, undefined);
+
+  const second = await hit(app, {
+    headers: { "If-None-Match": first.headers.etag ?? 'W/"stale-cache-validator"' },
+  });
+  assert.equal(second.status, 200);
+  assert.deepEqual(second.body, { items: [], nextCursor: null, total: 0 });
+  assert.equal(second.headers["cache-control"], "no-store, max-age=0");
+  assert.equal(second.headers.etag, undefined);
+});


### PR DESCRIPTION
## Summary
- Disable Express ETags for dynamic app responses.
- Add no-store cache headers for `/api/*` routes.
- Add a regression test proving conditional API requests return JSON `200` responses instead of `304`.

Closes #73.

## Testing
- It works
