### PR TITLE
썸네일 백필 실패 항목 보고 개선

### DIFF
--- a/bin/commands/backfillThumbs.ts
+++ b/bin/commands/backfillThumbs.ts
@@ -16,4 +16,10 @@ export async function backfillThumbs() {
 
   if (r.created > 0) invalidateHistoryIndex();
   console.log(`[thumbs] Done: ${r.created} created, ${r.skipped} skipped (already exist), ${r.failed} failed out of ${r.total} media files.`);
+  if (r.failures.length > 0) {
+    console.log(`[thumbs] Showing ${r.failures.length} thumbnail failure(s):`);
+    for (const failure of r.failures) {
+      console.log(`  - ${failure.kind}: ${failure.file} (${failure.reason})`);
+    }
+  }
 }

--- a/lib/thumbBackfill.ts
+++ b/lib/thumbBackfill.ts
@@ -3,12 +3,25 @@ import { join } from "node:path";
 import { ensureVideoThumbnail, videoThumbExists } from "./videoThumb.js";
 import { generateImageThumbnail, imageThumbExists } from "./imageThumb.js";
 
+export type ThumbBackfillFailure = {
+  file: string;
+  kind: "image" | "video";
+  reason: string;
+};
+
 export type ThumbBackfillResult = {
   total: number;
   created: number;
   skipped: number;
   failed: number;
+  failures: ThumbBackfillFailure[];
 };
+
+const FAILURE_DETAIL_LIMIT = 20;
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /**
  * Recursively scan `dir` (up to `maxDepth` levels, matching historyList's walk
@@ -22,7 +35,13 @@ export async function backfillThumbnails(
   dir: string,
   maxDepth = 2,
 ): Promise<ThumbBackfillResult> {
-  const result: ThumbBackfillResult = { total: 0, created: 0, skipped: 0, failed: 0 };
+  const result: ThumbBackfillResult = { total: 0, created: 0, skipped: 0, failed: 0, failures: [] };
+
+  function recordFailure(file: string, kind: "image" | "video", reason: string): void {
+    result.failed++;
+    if (result.failures.length >= FAILURE_DETAIL_LIMIT) return;
+    result.failures.push({ file, kind, reason });
+  }
 
   async function walk(current: string, depth: number): Promise<void> {
     const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
@@ -37,18 +56,19 @@ export async function backfillThumbnails(
       if (!/\.(png|jpe?g|webp|mp4)$/i.test(entry.name)) continue;
 
       result.total++;
+      const kind = /\.mp4$/i.test(entry.name) ? "video" : "image";
       try {
-        if (/\.mp4$/i.test(entry.name)) {
+        if (kind === "video") {
           if (await videoThumbExists(full)) { result.skipped++; continue; }
           const ok = await ensureVideoThumbnail(current, entry.name);
-          if (ok) result.created++; else result.failed++;
+          if (ok) result.created++; else recordFailure(full, kind, "thumbnail generation returned false");
         } else {
           if (await imageThumbExists(full)) { result.skipped++; continue; }
           await generateImageThumbnail(full);
           result.created++;
         }
-      } catch {
-        result.failed++;
+      } catch (error) {
+        recordFailure(full, kind, errorReason(error));
       }
     }
   }

--- a/tests/thumb-backfill.test.ts
+++ b/tests/thumb-backfill.test.ts
@@ -48,7 +48,7 @@ test("thumbnail backfill recursively covers nested media and skips trash", async
 
     const result = await backfillThumbnails(root);
 
-    assert.deepEqual(result, { total: 2, created: 1, skipped: 1, failed: 0 });
+    assert.deepEqual(result, { total: 2, created: 1, skipped: 1, failed: 0, failures: [] });
     assert.equal(await exists(thumbPathForImage(imagePath)), true);
     assert.equal(await exists(thumbPathForImage(trashImagePath)), false);
   } finally {
@@ -61,5 +61,26 @@ test("thumbnail backfill treats a missing generated directory as empty", async (
 
   const result = await backfillThumbnails(missing);
 
-  assert.deepEqual(result, { total: 0, created: 0, skipped: 0, failed: 0 });
+  assert.deepEqual(result, { total: 0, created: 0, skipped: 0, failed: 0, failures: [] });
+});
+
+test("thumbnail backfill reports files that fail thumbnail generation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ima2-thumb-backfill-failure-"));
+  try {
+    const badImagePath = join(root, "bad.png");
+    await writeFile(badImagePath, "not an image");
+
+    const result = await backfillThumbnails(root);
+
+    assert.equal(result.total, 1);
+    assert.equal(result.created, 0);
+    assert.equal(result.skipped, 0);
+    assert.equal(result.failed, 1);
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0].file, badImagePath);
+    assert.equal(result.failures[0].kind, "image");
+    assert.match(result.failures[0].reason, /unsupported image format|Input file/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## 요약
- 썸네일 백필 결과에 실패한 파일의 종류, 경로, 사유를 제한된 목록으로 포함했습니다.
- `ima2 backfill-thumbs` 실행 후 실패 항목 일부를 바로 출력하도록 했습니다.
- 손상된 이미지가 실패 통계와 상세 목록에 포함되는지 테스트를 추가했습니다.

## 배경
기존 백필 결과는 실패 개수만 보여줘서 어떤 파일을 정리해야 하는지 알기 어려웠습니다. 실패 상세를 함께 반환하면 손상 파일이나 지원되지 않는 입력을 바로 확인할 수 있습니다.

## 검증
- `npm run ui:install`
- `npm run ui:build`
- `npm run build:server`
- `npm run build:cli`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm test`
