### PR TITLE
fix(agy): recover generated artifact when CLI output is not captured

### DIFF
--- a/lib/agyImageAdapter.ts
+++ b/lib/agyImageAdapter.ts
@@ -115,6 +115,49 @@ function parseAgyOutput(stdout: string): { artifactPath: string; ext: string } {
   );
 }
 
+async function findRecentAgyArtifact(sinceMs: number): Promise<string | null> {
+  const roots = [
+    join(homedir(), ".gemini", "antigravity-cli", "brain"),
+    join(homedir(), ".gemini"),
+  ];
+
+  const candidates: { path: string; mtimeMs: number }[] = [];
+  const seen = new Set<string>();
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 5 || seen.has(dir)) return;
+    seen.add(dir);
+
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const p = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(p, depth + 1);
+        continue;
+      }
+
+      if (!/^ima2_generated.*\.(png|jpg|jpeg|webp)$/i.test(entry.name)) {
+        continue;
+      }
+
+      const s = await stat(p).catch(() => null);
+      if (!s) continue;
+
+      if (s.mtimeMs >= sinceMs - 5_000) {
+        candidates.push({ path: p, mtimeMs: s.mtimeMs });
+      }
+    }
+  }
+
+  for (const root of roots) {
+    await walk(root, 0);
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0]?.path ?? null;
+}
+
 function spawnAgy(prompt: string, signal?: AbortSignal): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const child = spawn("agy", ["-p", "-"], {
@@ -252,6 +295,7 @@ export async function generateViaAgy(
   });
 
   try {
+    const generationStartedAtMs = Date.now();
     const { stdout, stderr } = await spawnAgy(agyPrompt, options.signal);
 
     if (stderr && stderr.trim().length > 0) {
@@ -262,7 +306,30 @@ export async function generateViaAgy(
       });
     }
 
-    const { artifactPath } = parseAgyOutput(stdout);
+    const agyCombinedOutput = [stdout, stderr].filter(Boolean).join("\n");
+
+    let artifactPath: string;
+    try {
+      artifactPath = parseAgyOutput(agyCombinedOutput).artifactPath;
+    } catch (err) {
+      if ((err as any)?.code !== "AGY_PARSE_FAILED") {
+        throw err;
+      }
+
+      const fallbackPath = await findRecentAgyArtifact(generationStartedAtMs);
+      if (!fallbackPath) {
+        throw err;
+      }
+
+      logEvent("agy", "generate:fallback_artifact_found", {
+        requestId: options.requestId,
+        artifactPath: fallbackPath,
+        stdoutChars: stdout.length,
+        stderrChars: stderr.length,
+      });
+
+      artifactPath = fallbackPath;
+    }
 
     // Validate artifact path is within allowed directories
     const resolvedPath = resolve(artifactPath);


### PR DESCRIPTION
Fixes AGY/Antigravity image generations where the CLI successfully creates an artifact but ima2-gen fails with AGY_PARSE_FAILED because the expected RESULT line is not captured on stdout.

Changes:
- Parse combined stdout + stderr for AGY RESULT output.
- On AGY_PARSE_FAILED only, scan recent Antigravity/Gemini artifacts under ~/.gemini.
- Preserve existing validation and only recover when a fresh ima2_generated image exists.
- Log fallback recovery via agy generate:fallback_artifact_found.

Tested locally on Windows with Antigravity/AGY: image generation succeeded and ima2-gen ingested the generated artifact instead of failing with AGY_PARSE_FAILED.