### PR TITLE
Fix Windows installer npm handling

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -99,7 +99,7 @@ Ok "Node $(node --version), npm $npmVersion"
 # Pre-clean: force-remove stale locks from previous versions
 $npmGlobal = (npm prefix -g 2>$null)
 if ($npmGlobal) {
-    $lockCandidate = Join-Path $npmGlobal 'node_modules' '.package-lock.json'
+    $lockCandidate = Join-Path (Join-Path $npmGlobal 'node_modules') '.package-lock.json'
     if (Test-Path $lockCandidate) {
         try {
             Remove-Item $lockCandidate -Force -ErrorAction SilentlyContinue
@@ -112,16 +112,41 @@ $installArgs = @('install', '-g', 'ima2-gen')
 if ($npmMajor -ge 12) {
     $installArgs += '--allow-scripts=ima2-gen,better-sqlite3,sharp'
 }
-$output = & npm @installArgs 2>&1
-if ($LASTEXITCODE -ne 0) {
+
+function Invoke-Npm {
+    param([string[]]$Arguments)
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        # PowerShell 5.1 promotes native stderr (including npm warnings) to
+        # ErrorRecord objects. Keep those in the captured output so warnings
+        # do not abort the installer before npm's exit code is checked.
+        $ErrorActionPreference = 'Continue'
+        $result = & npm @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    [pscustomobject]@{
+        Output   = @($result)
+        ExitCode = $exitCode
+    }
+}
+
+$installResult = Invoke-Npm $installArgs
+$output = $installResult.Output
+if ($installResult.ExitCode -ne 0) {
     $outputStr = $output -join "`n"
     if ($outputStr -match 'EBUSY|EPERM|resource busy') {
         Warn 'File lock detected. Killing all node processes and retrying…'
         Get-Process node -ErrorAction SilentlyContinue | Stop-Process -Force
         Start-Sleep -Seconds 3
         npm cache clean --force 2>$null
-        $output = & npm @installArgs 2>&1
-        if ($LASTEXITCODE -ne 0) {
+        $installResult = Invoke-Npm $installArgs
+        $output = $installResult.Output
+        if ($installResult.ExitCode -ne 0) {
             Write-Host ($output -join "`n")
             Fail 'Install still failed after cleanup. Reboot, then run this script again before starting ima2.'
         }

--- a/site/public/install-windows.ps1
+++ b/site/public/install-windows.ps1
@@ -99,7 +99,7 @@ Ok "Node $(node --version), npm $npmVersion"
 # Pre-clean: force-remove stale locks from previous versions
 $npmGlobal = (npm prefix -g 2>$null)
 if ($npmGlobal) {
-    $lockCandidate = Join-Path $npmGlobal 'node_modules' '.package-lock.json'
+    $lockCandidate = Join-Path (Join-Path $npmGlobal 'node_modules') '.package-lock.json'
     if (Test-Path $lockCandidate) {
         try {
             Remove-Item $lockCandidate -Force -ErrorAction SilentlyContinue
@@ -112,16 +112,41 @@ $installArgs = @('install', '-g', 'ima2-gen')
 if ($npmMajor -ge 12) {
     $installArgs += '--allow-scripts=ima2-gen,better-sqlite3,sharp'
 }
-$output = & npm @installArgs 2>&1
-if ($LASTEXITCODE -ne 0) {
+
+function Invoke-Npm {
+    param([string[]]$Arguments)
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        # PowerShell 5.1 promotes native stderr (including npm warnings) to
+        # ErrorRecord objects. Keep those in the captured output so warnings
+        # do not abort the installer before npm's exit code is checked.
+        $ErrorActionPreference = 'Continue'
+        $result = & npm @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    [pscustomobject]@{
+        Output   = @($result)
+        ExitCode = $exitCode
+    }
+}
+
+$installResult = Invoke-Npm $installArgs
+$output = $installResult.Output
+if ($installResult.ExitCode -ne 0) {
     $outputStr = $output -join "`n"
     if ($outputStr -match 'EBUSY|EPERM|resource busy') {
         Warn 'File lock detected. Killing all node processes and retrying…'
         Get-Process node -ErrorAction SilentlyContinue | Stop-Process -Force
         Start-Sleep -Seconds 3
         npm cache clean --force 2>$null
-        $output = & npm @installArgs 2>&1
-        if ($LASTEXITCODE -ne 0) {
+        $installResult = Invoke-Npm $installArgs
+        $output = $installResult.Output
+        if ($installResult.ExitCode -ne 0) {
             Write-Host ($output -join "`n")
             Fail 'Install still failed after cleanup. Reboot, then run this script again before starting ima2.'
         }

--- a/tests/install-windows-contract.test.js
+++ b/tests/install-windows-contract.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const installerPaths = [
+  join(process.cwd(), "scripts", "install-windows.ps1"),
+  join(process.cwd(), "site", "public", "install-windows.ps1"),
+];
+
+test("Windows installers use PowerShell 5.1-safe npm handling", () => {
+  for (const installerPath of installerPaths) {
+    const script = readFileSync(installerPath, "utf8");
+
+    assert.match(
+      script,
+      /Join-Path \(Join-Path \$npmGlobal 'node_modules'\) '\.package-lock\.json'/,
+      `${installerPath} should compose the npm lockfile path with nested Join-Path calls`,
+    );
+    assert.doesNotMatch(
+      script,
+      /Join-Path \$npmGlobal 'node_modules' '\.package-lock\.json'/,
+      `${installerPath} should not pass three positional arguments to Join-Path`,
+    );
+    assert.match(script, /function Invoke-Npm/, `${installerPath} should isolate native npm invocation`);
+    assert.match(
+      script,
+      /\$ErrorActionPreference = 'Continue'/,
+      `${installerPath} should allow npm warnings to be captured without aborting the installer`,
+    );
+    assert.match(script, /\$installResult\.ExitCode -ne 0/, `${installerPath} should check npm's exit code`);
+  }
+});
+
+test("published and source Windows installers stay in sync", () => {
+  const [source, published] = installerPaths.map((path) => readFileSync(path, "utf8"));
+  assert.equal(published, source);
+});


### PR DESCRIPTION
## Summary

Fixes #110.

This PR makes the Windows installer complete reliably when npm emits warnings during installation.

## Changes

- Compose the global npm lockfile path with nested `Join-Path` calls.
- Capture npm output with a temporary `Continue` error action preference so PowerShell 5.1 does not terminate on native npm warnings.
- Continue to use npm's exit code for install and retry decisions.
- Add a regression test covering both installer copies and their synchronization.

## Root cause

The installer passed three positional arguments to `Join-Path`, which only accepts the path and child-path arguments in the supported PowerShell versions. Separately, the script's global `Stop` error policy converted npm stderr warnings into terminating errors before the npm exit code could be evaluated.

## Validation

- `node --test tests/install-windows-contract.test.js` — 2 passed.
- PowerShell UTF-8 parser check — both installer copies passed.
- `git diff --check` — passed.
- `npm test` — timed out after 120 seconds in this checkout; dependencies were installed with `npm ci` first.