### PR TITLE
Bundle zod in global installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,7 @@ jobs:
       - name: Package install smoke
         run: npm run test:package-install
         timeout-minutes: 15
-      - name: Windows global update and package-local OAuth smoke
-        if: runner.os == 'Windows'
+      - name: Global install, update, and package-local OAuth smoke
         run: npm run test:package-global-update
         timeout-minutes: 15
       - name: CLI smoke (grok --help)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.0.15",
       "bundleDependencies": [
         "progrok",
-        "openai-oauth"
+        "openai-oauth",
+        "zod"
       ],
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
   },
   "bundleDependencies": [
     "progrok",
-    "openai-oauth"
+    "openai-oauth",
+    "zod"
   ],
   "allowScripts": {
     "better-sqlite3@12.9.0": true,

--- a/scripts/package-global-update-smoke.mjs
+++ b/scripts/package-global-update-smoke.mjs
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 
 import { spawnNpmSync } from "./npm-subprocess.mjs";
 import { parsePackOutput } from "./release-artifact-contract.mjs";
@@ -58,6 +58,19 @@ function candidateTarball(root) {
   return join(packDir, parsePackOutput(packed.stdout).filename);
 }
 
+function assertPackagedZod(prefix) {
+  const globalRoot = runNpm(["root", "--global", "--prefix", prefix]).stdout.trim();
+  const packageRoot = join(globalRoot, "ima2-gen");
+  const installedRequire = createRequire(join(packageRoot, "package.json"));
+  const zodRoot = realpathSync(join(packageRoot, "node_modules", "zod"));
+  const zodV4Entry = realpathSync(installedRequire.resolve("zod/v4"));
+  assert.ok(
+    zodV4Entry.startsWith(`${zodRoot}${sep}`),
+    `zod/v4 should resolve from the packaged ima2-gen tree: ${zodV4Entry}`,
+  );
+  return packageRoot;
+}
+
 function runGlobalShim(prefix, args, options = {}) {
   const shim = process.platform === "win32" ? join(prefix, "ima2.cmd") : join(prefix, "bin", "ima2");
   assert.equal(existsSync(shim), true, `global ima2 shim should exist: ${shim}`);
@@ -79,14 +92,17 @@ function main() {
     mkdirSync(unrelatedCwd, { recursive: true });
     writeFileSync(join(config, "config.json"), JSON.stringify({ provider: "oauth" }));
 
+    const tarball = candidateTarball(root);
+    const cleanPrefix = join(root, "clean-prefix");
+    installGlobal(cleanPrefix, tarball);
+    assertPackagedZod(cleanPrefix);
+
     const baseline = process.env.IMA2_UPDATE_BASELINE || "ima2-gen@latest";
     installGlobal(prefix, baseline);
     const baselineVersion = runGlobalShim(prefix, ["--version"], { cwd: unrelatedCwd }).stdout.trim();
 
-    const tarball = candidateTarball(root);
     installGlobal(prefix, tarball);
-    const globalRoot = runNpm(["root", "--global", "--prefix", prefix]).stdout.trim();
-    const packageRoot = join(globalRoot, "ima2-gen");
+    const packageRoot = assertPackagedZod(prefix);
     const cliPath = join(packageRoot, "bin", "ima2.js");
     const installed = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
     const installedRequire = createRequire(join(packageRoot, "package.json"));

--- a/tests/package-install-smoke.mjs
+++ b/tests/package-install-smoke.mjs
@@ -124,7 +124,7 @@ test("packaged tarball installs, serves core status routes, and keeps Card News 
         cwd: process.cwd(),
       });
       const packManifest = [parsePackOutput(pack.stdout)];
-      for (const bundled of ["progrok", "openai-oauth"]) {
+      for (const bundled of ["progrok", "openai-oauth", "zod"]) {
         assert.ok(packManifest[0].bundled.includes(bundled), `packed artifact should bundle ${bundled}`);
       }
       tarball = join(packDir, packManifest[0].filename);
@@ -170,7 +170,7 @@ test("packaged tarball installs, serves core status routes, and keeps Card News 
     const progrokBin = packageBin("progrok", "progrok");
     const oauthBin = packageBin("openai-oauth", "openai-oauth");
     const codexBin = packageBin("@openai/codex", "codex");
-    assert.doesNotThrow(() => installedRequire.resolve("zod"));
+    assert.doesNotThrow(() => installedRequire.resolve("zod/v4"));
 
     const oauthRoot = join(packageRoot, "node_modules", "openai-oauth");
     const oauthPackage = JSON.parse(readFileSync(join(oauthRoot, "package.json"), "utf8"));


### PR DESCRIPTION
Fixes #112

## Summary

- Bundle zod with the packaged OAuth dependency tree.
- Verify clean global installs resolve zod/v4 from ima2-gen itself.
- Run the global install/update smoke across the CI matrix.

## Validation

- npm test (1,134 tests)
- npm run typecheck
- npm run typecheck:tests
- npm run test:package-install
- npm run test:package-global-update with npm 11.12.1 and npm 12.0.1
- npm run test:install-policy
- npm run test:inventory
- npm run lint:pkg