### PR TITLE
Add Atlas Cloud image provider

### DIFF
--- a/bin/commands/edit.ts
+++ b/bin/commands/edit.ts
@@ -8,8 +8,8 @@ import { createCliRequestId, recoverGeneratedOutputs, formatRecoveryHint } from 
 import { errInfo } from "../../lib/errInfo.js";
 const VALID_MODES = new Set(["auto", "direct"]);
 const VALID_MODERATION = new Set(["auto", "low"]);
-const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"]);
-const KNOWN_IMAGE_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark", "grok-imagine-image", "grok-imagine-image-quality", "nano-banana-2", "nano-banana-pro"]);
+const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"]);
+const KNOWN_IMAGE_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark", "grok-imagine-image", "grok-imagine-image-quality", "nano-banana-2", "nano-banana-pro", "openai/gpt-image-2/text-to-image", "openai/gpt-image-2/edit"]);
 
 const SPEC = {
   flags: {
@@ -43,9 +43,9 @@ const HELP = `
     -s, --size <WxH>
     -o, --out <file>
         --json
-        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro>
-        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api>
-                                      Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini)
+        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro|openai/gpt-image-2/text-to-image|openai/gpt-image-2/edit>
+        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>
+                                      Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini; atlascloud = Atlas Cloud)
         --mode <auto|direct>       Prompt handling mode. Default: auto
         --moderation <auto|low>    Default: low
         --session <id>             Apply session style sheet if enabled
@@ -62,10 +62,10 @@ export default async function editCmd(argv: string[]) {
   if (!VALID_MODES.has(String(args.mode))) die(2, "--mode must be one of: auto, direct");
   if (!VALID_MODERATION.has(String(args.moderation))) die(2, "--moderation must be one of: auto, low");
   if (args.provider && !VALID_PROVIDERS.has(String(args.provider))) {
-    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api");
+    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud");
   }
   if (args.model && !KNOWN_IMAGE_MODELS.has(String(args.model))) {
-    die(2, "--model must be one of: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.3-codex-spark, grok-imagine-image, grok-imagine-image-quality, nano-banana-2, nano-banana-pro");
+    die(2, "--model must be one of: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.3-codex-spark, grok-imagine-image, grok-imagine-image-quality, nano-banana-2, nano-banana-pro, openai/gpt-image-2/text-to-image, openai/gpt-image-2/edit");
   }
   const VALID_REASONING = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
   if (args["reasoning-effort"] && !VALID_REASONING.has(String(args["reasoning-effort"]))) {

--- a/bin/commands/gen.ts
+++ b/bin/commands/gen.ts
@@ -8,8 +8,8 @@ import { createCliRequestId, recoverGeneratedOutputs, formatRecoveryHint } from 
 import { errInfo } from "../../lib/errInfo.js";
 const VALID_MODES = new Set(["auto", "direct"]);
 const VALID_MODERATION = new Set(["auto", "low"]);
-const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"]);
-const KNOWN_IMAGE_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark", "grok-imagine-image", "grok-imagine-image-quality", "nano-banana-2", "nano-banana-pro"]);
+const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"]);
+const KNOWN_IMAGE_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark", "grok-imagine-image", "grok-imagine-image-quality", "nano-banana-2", "nano-banana-pro", "openai/gpt-image-2/text-to-image", "openai/gpt-image-2/edit"]);
 const MAX_GENERATION_COUNT = Math.max(1, Math.trunc(Number(config.limits.maxGeneratedImages) || 24));
 const MAX_REFERENCE_COUNT = Math.max(1, Math.trunc(Number(config.limits.maxRefCount) || 5));
 
@@ -61,9 +61,9 @@ const HELP = `
         --stdin                              Read prompt from stdin
         --timeout <sec>                     Default: 180
         --server <url>                      Override server URL
-        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro>
-        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api>
-                                            Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini)
+        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro|openai/gpt-image-2/text-to-image|openai/gpt-image-2/edit>
+        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>
+                                            Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini; atlascloud = Atlas Cloud)
         --mode <auto|direct>                Prompt handling mode. Default: auto
         --moderation <auto|low>             Default: low
         --session <id>                      Apply session style sheet if enabled
@@ -95,10 +95,10 @@ export default async function genCmd(argv: string[]) {
   if (!VALID_MODES.has(String(args.mode))) die(2, "--mode must be one of: auto, direct");
   if (!VALID_MODERATION.has(String(args.moderation))) die(2, "--moderation must be one of: auto, low");
   if (args.provider && !VALID_PROVIDERS.has(String(args.provider))) {
-    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api");
+    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud");
   }
   if (args.model && !KNOWN_IMAGE_MODELS.has(String(args.model))) {
-    die(2, "--model must be one of: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.3-codex-spark, grok-imagine-image, grok-imagine-image-quality, nano-banana-2, nano-banana-pro");
+    die(2, "--model must be one of: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.3-codex-spark, grok-imagine-image, grok-imagine-image-quality, nano-banana-2, nano-banana-pro, openai/gpt-image-2/text-to-image, openai/gpt-image-2/edit");
   }
   const VALID_REASONING = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
   if (args["reasoning-effort"] && !VALID_REASONING.has(String(args["reasoning-effort"]))) {

--- a/bin/commands/multimode.ts
+++ b/bin/commands/multimode.ts
@@ -45,9 +45,9 @@ const HELP = `
     -o, --out <file>                    First image (implies --max-images 1)
     -d, --out-dir <dir>                 Output dir for multiple images
         --json
-        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro>
-        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api>
-                                      Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini)
+        --model <gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|grok-imagine-image|grok-imagine-image-quality|nano-banana-2|nano-banana-pro|openai/gpt-image-2/text-to-image|openai/gpt-image-2/edit>
+        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>
+                                      Provider (oauth = GPT OAuth; grok = xAI Grok; agy/gemini-api = Gemini; atlascloud = Atlas Cloud)
         --mode <auto|direct>            Prompt handling mode. Default: auto
         --ref <file>                    Attach reference image (repeatable, max ${MAX_REFERENCE_COUNT})
         --reasoning-effort <none|low|medium|high|xhigh|max>
@@ -64,11 +64,11 @@ export default async function multimodeCmd(argv: string[]) {
   const prompt = args.positional.join(" ");
   if (!prompt) die(2, "prompt required");
 
-  const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"]);
+  const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"]);
   const VALID_MODES = new Set(["auto", "direct"]);
   const VALID_REASONING = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
   if (args.provider && !VALID_PROVIDERS.has(String(args.provider))) {
-    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api");
+    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud");
   }
   if (!VALID_MODES.has(String(args.mode))) die(2, "--mode must be one of: auto, direct");
   if (args["reasoning-effort"] && !VALID_REASONING.has(String(args["reasoning-effort"]))) {

--- a/bin/commands/node.ts
+++ b/bin/commands/node.ts
@@ -11,11 +11,11 @@ const HELP = `
   ima2 node <subcommand> [options]
 
   Subcommands:
-    generate <prompt...> [--parent <nodeId>] [--ref <file>...] [--provider <auto|oauth|api|grok|grok-api|agy|gemini-api>] [--no-stream] [...gen-style flags]
+    generate <prompt...> [--parent <nodeId>] [--ref <file>...] [--provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>] [--no-stream] [...gen-style flags]
     show <nodeId> [--json]
 
   Generate options:
-        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api>  Provider for this request
+        --provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>  Provider for this request
 `;
 
 const GEN_FLAGS = {
@@ -56,10 +56,10 @@ async function generateSub(argv: string[]) {
   const prompt = args.positional.join(" ");
   if (!prompt) die(2, "prompt required");
   const refs = (Array.isArray(args.ref) ? args.ref : []) as string[];
-  const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"]);
+  const VALID_PROVIDERS = new Set(["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"]);
   const VALID_REASONING = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
   if (args.provider && !VALID_PROVIDERS.has(String(args.provider))) {
-    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api");
+    die(2, "--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud");
   }
   if (args["reasoning-effort"] && !VALID_REASONING.has(String(args["reasoning-effort"]))) {
     die(2, "--reasoning-effort must be one of: none, low, medium, high, xhigh, max");

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,7 +69,7 @@ Agents should start from the packaged skill and capability commands instead of g
 | `ima2 node generate` | Node-mode generate (SSE; supports `--no-stream`) |
 | `ima2 node show <nodeId>` | Read node metadata |
 
-Generation flags include `--provider <auto|oauth|api|grok|grok-api|agy|gemini-api>`, `--reasoning-effort {none\|low\|medium\|high\|xhigh\|max}`, `--web-search` / `--no-web-search`, `--model`, `--mode`, `--moderation`, `--ref <file>` (repeatable, up to 5 where supported), `-q low|medium|high`, `-n <count>`, `-o <file>`.
+Generation flags include `--provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>`, `--reasoning-effort {none\|low\|medium\|high\|xhigh\|max}`, `--web-search` / `--no-web-search`, `--model`, `--mode`, `--moderation`, `--ref <file>` (repeatable, up to 5 where supported), `-q low|medium|high`, `-n <count>`, `-o <file>`.
 
 Provider override semantics:
 
@@ -78,6 +78,7 @@ Provider override semantics:
 - `grok` uses the bundled progrok xAI proxy (`127.0.0.1:18645`). Classic generation first runs mandatory xAI Web Search through Responses API, then asks `grok-4.3` to call ima2's local `generate_image` tool, then ima2 executes xAI `/v1/images/generations`. If `--ref` images are attached, the final step uses xAI `/v1/images/edits` instead so image-to-image/reference context is preserved. Models: `grok-imagine-image`, `grok-imagine-image-quality`. Size is mapped to xAI `aspect_ratio` and `resolution`; the UI web-search toggle is OpenAI-provider-only because Grok search is always on in this path.
 - `agy` spawns the Antigravity CLI to generate via Google Gemini (`nano-banana-2`). Fixed 1024×1024 JPEG output, max 3 refs. No web search, quality, size, or mask controls. If `agy` is not on the server process PATH, ima2 also checks common user-local installs such as `~/.local/bin/agy`; set `IMA2_AGY_BIN=/absolute/path/to/agy` to force a specific binary.
 - `gemini-api` calls the Google Generative Language API directly. Models: `nano-banana-2` (Gemini 3.1 Flash Image) and `nano-banana-pro` (Gemini 3 Pro Image). Use `--model nano-banana-2` or `--model nano-banana-pro` to select. Supports `--size` for aspect ratio and resolution (512px–4K) on the direct API path; Vertex AI ignores aspect/size. Requires `GEMINI_API_KEY` or a Vertex AI service account (`VERTEX_SERVICE_ACCOUNT_JSON`). Switching from `agy` or `gemini-api` provider auto-selects the corresponding Gemini model; switching away resets to the GPT default.
+- `atlascloud` calls Atlas Cloud's OpenAI-compatible Media API directly. Models: `openai/gpt-image-2/text-to-image` for text-to-image and `openai/gpt-image-2/edit` when references are attached. Requires `ATLASCLOUD_API_KEY`; references are uploaded before edit requests, and web search, reasoning, mask, and video controls are ignored on this provider.
 - `auto` preserves route default behavior and currently resolves to GPT OAuth unless server routing changes.
 
 `ima2 serve` starts the bundled Grok proxy automatically. No separate `progrok`
@@ -123,7 +124,7 @@ mockup`.
 For dense or critical text, keep the text large and explicit. Exact placement,
 small text, and pixel-perfect typography can still need iteration or post-editing.
 
-Multimode-specific flags include `--max-images <1..24>` by default (configurable through `IMA2_MAX_GENERATED_IMAGES`), `--ref <file>` (repeatable, max 5), `--mode <auto|direct>`, `--provider <auto|oauth|api|grok|grok-api|agy|gemini-api>`, and `--show-partial`. `ima2 edit --mask` remains intentionally deferred to #31 because current mask plumbing is guided edit rather than guaranteed true masked/inpaint semantics.
+Multimode-specific flags include `--max-images <1..24>` by default (configurable through `IMA2_MAX_GENERATED_IMAGES`), `--ref <file>` (repeatable, max 5), `--mode <auto|direct>`, `--provider <auto|oauth|api|grok|grok-api|agy|gemini-api|atlascloud>`, and `--show-partial`. `ima2 edit --mask` remains intentionally deferred to #31 because current mask plumbing is guided edit rather than guaranteed true masked/inpaint semantics.
 
 ## Video
 

--- a/lib/agentImageVideoGen.ts
+++ b/lib/agentImageVideoGen.ts
@@ -11,6 +11,7 @@ import { resolveProviderOptions } from "./providerOptions.js";
 import { generateViaResponses } from "./responsesImageAdapter.js";
 import { generateViaGrok, type GrokReferenceImage } from "./grokImageAdapter.js";
 import { generateViaAgy } from "./agyImageAdapter.js";
+import { generateViaAtlasCloud } from "./atlasCloudImageAdapter.js";
 import { generateVideoViaGrok, type GrokVideoGenerateResult } from "./grokVideoAdapter.js";
 import { GROK_VIDEO_MODEL_15, GROK_VIDEO_MODEL_BASE } from "./imageModels.js";
 import { parseVideoParams } from "./agentGenerationPlanner.js";
@@ -90,6 +91,15 @@ async function generateAgentImage(
         requestId,
         signal: options.signal ?? undefined,
       })
+    : activeProvider === "atlascloud"
+    ? await generateViaAtlasCloud(`${manifest}\n\nUser request:\n${prompt}`, ctx, {
+        model: effectiveModel,
+        size: providerOptions.size,
+        quality: options.quality ?? "medium",
+        requestId,
+        signal: options.signal ?? undefined,
+        references: await loadAgentCurrentImageReferences(ctx, sessionId, options.sourceImagePolicy ?? "none"),
+      })
     : activeProvider === "grok"
     ? await generateViaGrok(`${manifest}\n\nUser request:\n${prompt}`, ctx, {
         model: effectiveModel,
@@ -116,7 +126,7 @@ async function generateAgentImage(
           signal: options.signal,
         },
       );
-  const format = activeProvider === "grok" || activeProvider === "agy"
+  const format = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "atlascloud"
     ? imageFormatFromMime(("mime" in response ? response.mime : undefined) || detectImageMimeFromB64(response.b64) || "image/jpeg")
     : options.format ?? "png";
   const image = await persistAgentImage(ctx, sessionId, prompt, format, requestId, response, {

--- a/lib/agentSettings.ts
+++ b/lib/agentSettings.ts
@@ -1,7 +1,7 @@
 import { config } from "../config.js";
 import type { AgentGenerationSettings } from "./agentTypes.js";
 
-const PROVIDERS = new Set(["oauth", "api", "grok", "grok-api", "agy", "gemini-api"]);
+const PROVIDERS = new Set(["oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"]);
 const QUALITIES = new Set(["low", "medium", "high"]);
 const FORMATS = new Set(["png", "jpeg", "webp"]);
 const MODERATIONS = new Set(["auto", "low"]);

--- a/lib/atlasCloudImageAdapter.ts
+++ b/lib/atlasCloudImageAdapter.ts
@@ -1,0 +1,234 @@
+import type { RuntimeContext } from "./runtimeContext.js";
+import { detectImageMimeFromB64 } from "./refs.js";
+import { logEvent } from "./logger.js";
+
+const ATLAS_BASE_URL = "https://api.atlascloud.ai/api/v1";
+export const ATLASCLOUD_TEXT_TO_IMAGE_MODEL = "openai/gpt-image-2/text-to-image";
+export const ATLASCLOUD_EDIT_MODEL = "openai/gpt-image-2/edit";
+
+type AtlasReference = {
+  b64: string;
+  declaredMime?: string | null;
+  detectedMime?: string | null;
+};
+
+type AtlasGenerateOptions = {
+  model?: string;
+  size?: string;
+  quality?: string;
+  outputFormat?: "jpeg" | "png";
+  references?: AtlasReference[];
+  signal?: AbortSignal;
+  requestId?: string;
+};
+
+type AtlasImageResult = {
+  b64: string;
+  revisedPrompt?: string | null;
+  usage: Record<string, number> | null;
+  webSearchCalls: number;
+  mime?: string;
+  providerUrl?: string | null;
+};
+
+function atlasCloudError(message: string, status: number, code: string): Error {
+  const err = new Error(message) as Error & { status?: number; code?: string; isOperational?: boolean };
+  err.status = status;
+  err.code = code;
+  err.isOperational = true;
+  return err;
+}
+
+async function readJson(res: Response): Promise<any> {
+  const text = await res.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+function firstString(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = firstString(item);
+      if (found) return found;
+    }
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    return firstString(obj.url)
+      || firstString(obj.image)
+      || firstString(obj.image_url)
+      || firstString(obj.download_url)
+      || firstString(obj.b64_json)
+      || firstString(obj.base64)
+      || firstString(obj.data);
+  }
+  return null;
+}
+
+function normalizeStatus(value: unknown): string {
+  return String(value || "").toLowerCase();
+}
+
+async function uploadReference(apiKey: string, ref: AtlasReference, index: number, signal?: AbortSignal): Promise<string> {
+  const mime = ref.detectedMime || ref.declaredMime || detectImageMimeFromB64(ref.b64) || "image/png";
+  const ext = mime.includes("jpeg") ? "jpg" : mime.includes("webp") ? "webp" : "png";
+  const bytes = Buffer.from(ref.b64, "base64");
+  const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const form = new FormData();
+  form.append("file", new Blob([arrayBuffer], { type: mime }), `reference-${index}.${ext}`);
+
+  const res = await fetch(`${ATLAS_BASE_URL}/model/uploadMedia`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+    signal,
+  });
+  const json = await readJson(res);
+  if (!res.ok) {
+    throw atlasCloudError(`Atlas Cloud media upload failed (${res.status})`, res.status, "ATLASCLOUD_UPLOAD_FAILED");
+  }
+  const url = firstString(json?.data) || firstString(json);
+  if (!url || !url.startsWith("http")) {
+    throw atlasCloudError("Atlas Cloud media upload did not return a URL", 502, "ATLASCLOUD_UPLOAD_NO_URL");
+  }
+  return url;
+}
+
+function predictionIdFrom(json: any): string | null {
+  return firstString(json?.data?.id)
+    || firstString(json?.data?.request_id)
+    || firstString(json?.id)
+    || firstString(json?.request_id);
+}
+
+async function submitGeneration(apiKey: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<string> {
+  const res = await fetch(`${ATLAS_BASE_URL}/model/generateImage`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+  const json = await readJson(res);
+  if (!res.ok) {
+    throw atlasCloudError(`Atlas Cloud image generation failed (${res.status})`, res.status, "ATLASCLOUD_GENERATE_FAILED");
+  }
+  const id = predictionIdFrom(json);
+  if (!id) {
+    throw atlasCloudError("Atlas Cloud image generation did not return a prediction id", 502, "ATLASCLOUD_NO_PREDICTION_ID");
+  }
+  return id;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) throw atlasCloudError("Generation canceled", 499, "GENERATION_CANCELED");
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(atlasCloudError("Generation canceled", 499, "GENERATION_CANCELED"));
+    }, { once: true });
+  });
+}
+
+async function fetchPrediction(apiKey: string, id: string, signal?: AbortSignal): Promise<any> {
+  const headers = { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
+  const primary = await fetch(`${ATLAS_BASE_URL}/model/result/${encodeURIComponent(id)}`, { headers, signal });
+  if (primary.status !== 404) return readJson(primary);
+  const fallback = await fetch(`${ATLAS_BASE_URL}/model/prediction/${encodeURIComponent(id)}`, { headers, signal });
+  return readJson(fallback);
+}
+
+async function pollOutputUrl(apiKey: string, id: string, signal?: AbortSignal): Promise<string> {
+  const deadline = Date.now() + 180_000;
+  let lastStatus = "starting";
+  while (Date.now() < deadline) {
+    const json = await fetchPrediction(apiKey, id, signal);
+    const data = json?.data || json;
+    lastStatus = normalizeStatus(data?.status || json?.status);
+    if (lastStatus === "failed" || lastStatus === "error" || lastStatus === "canceled") {
+      throw atlasCloudError(`Atlas Cloud generation failed: ${data?.error || data?.message || lastStatus}`, 502, "ATLASCLOUD_GENERATION_FAILED");
+    }
+    const output = firstString(data?.outputs) || firstString(data?.output) || firstString(data?.result);
+    if ((lastStatus === "completed" || lastStatus === "succeeded" || lastStatus === "success") && output) {
+      return output;
+    }
+    await sleep(3000, signal);
+  }
+  throw atlasCloudError(`Atlas Cloud generation timed out (last status: ${lastStatus})`, 504, "GENERATION_TIMEOUT");
+}
+
+async function downloadOutput(output: string, signal?: AbortSignal): Promise<{ b64: string; mime?: string; url?: string | null }> {
+  const dataUri = output.match(/^data:([^;]+);base64,(.+)$/);
+  if (dataUri) return { b64: dataUri[2], mime: dataUri[1], url: null };
+  if (/^[A-Za-z0-9+/=]+$/.test(output) && output.length > 100) {
+    return { b64: output, mime: "image/png", url: null };
+  }
+  const res = await fetch(output, { signal });
+  if (!res.ok) {
+    throw atlasCloudError(`Atlas Cloud output download failed (${res.status})`, 502, "ATLASCLOUD_OUTPUT_DOWNLOAD_FAILED");
+  }
+  const mime = res.headers.get("content-type") || undefined;
+  const b64 = Buffer.from(await res.arrayBuffer()).toString("base64");
+  return { b64, mime, url: output };
+}
+
+export async function generateViaAtlasCloud(
+  prompt: string,
+  ctx: RuntimeContext,
+  options: AtlasGenerateOptions = {},
+): Promise<AtlasImageResult> {
+  const apiKey = ctx.atlasCloudApiKey;
+  if (!apiKey) {
+    throw atlasCloudError("Atlas Cloud API key not configured", 401, "ATLASCLOUD_API_KEY_MISSING");
+  }
+  const references = options.references?.filter((ref) => ref.b64) || [];
+  if (references.length > 10) {
+    throw atlasCloudError("Atlas Cloud image editing supports up to 10 reference images", 400, "ATLASCLOUD_REF_TOO_MANY");
+  }
+  const model = references.length > 0 ? ATLASCLOUD_EDIT_MODEL : (options.model || ATLASCLOUD_TEXT_TO_IMAGE_MODEL);
+  const imageUrls = references.length
+    ? await Promise.all(references.map((ref, index) => uploadReference(apiKey, ref, index, options.signal)))
+    : [];
+  const body: Record<string, unknown> = {
+    model,
+    prompt,
+    size: options.size || "1024x1024",
+    quality: options.quality || "medium",
+    output_format: options.outputFormat || "jpeg",
+    enable_base64_output: false,
+    enable_sync_mode: false,
+  };
+  if (imageUrls.length) body.images = imageUrls;
+
+  logEvent("atlascloud", "generate:start", {
+    requestId: options.requestId,
+    model,
+    size: body.size,
+    refs: imageUrls.length,
+  });
+  const predictionId = await submitGeneration(apiKey, body, options.signal);
+  const output = await pollOutputUrl(apiKey, predictionId, options.signal);
+  const downloaded = await downloadOutput(output, options.signal);
+  logEvent("atlascloud", "generate:done", {
+    requestId: options.requestId,
+    model,
+    predictionId,
+    bytes: Buffer.byteLength(downloaded.b64, "base64"),
+  });
+  return {
+    b64: downloaded.b64,
+    revisedPrompt: null,
+    usage: null,
+    webSearchCalls: 0,
+    mime: downloaded.mime,
+    providerUrl: downloaded.url,
+  };
+}

--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -4,7 +4,7 @@ import { AGENT_TOOL_MANIFEST } from "./agentToolManifest.js";
 import { KEY_TO_ENV, WRITABLE_CONFIG_KEYS } from "./configKeys.js";
 import { DEFAULT_IMAGE_QUALITY, VALID_IMAGE_QUALITIES } from "./oauthNormalize.js";
 const VALID_MODES = ["auto", "direct"];
-const VALID_PROVIDERS = ["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"];
+const VALID_PROVIDERS = ["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"];
 const AGENT_COMMANDS = [
     "skill",
     "capabilities",
@@ -57,6 +57,7 @@ export function buildIma2Capabilities({ appConfig = runtimeConfigDefault, packag
                 unsupported: toArray(appConfig.imageModels.unsupported),
                 grokSupported: ["grok-imagine-image", "grok-imagine-image-quality"],
                 geminiSupported: ["nano-banana-2", "nano-banana-pro"],
+                atlasCloudSupported: ["openai/gpt-image-2/text-to-image", "openai/gpt-image-2/edit"],
             },
             videoModels: {
                 supported: ["grok-imagine-video", "grok-imagine-video-1.5"],

--- a/lib/capabilities.ts
+++ b/lib/capabilities.ts
@@ -8,7 +8,7 @@ import type { AppConfig } from "./runtimeContext.js";
 type CapabilitySource = "local" | "server";
 
 const VALID_MODES = ["auto", "direct"] as const;
-const VALID_PROVIDERS = ["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"] as const;
+const VALID_PROVIDERS = ["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"] as const;
 const AGENT_COMMANDS = [
   "skill",
   "capabilities",
@@ -71,6 +71,7 @@ export function buildIma2Capabilities({
         unsupported: toArray(appConfig.imageModels.unsupported),
         grokSupported: ["grok-imagine-image", "grok-imagine-image-quality"],
         geminiSupported: ["nano-banana-2", "nano-banana-pro"],
+        atlasCloudSupported: ["openai/gpt-image-2/text-to-image", "openai/gpt-image-2/edit"],
       },
       videoModels: {
         supported: ["grok-imagine-video", "grok-imagine-video-1.5"],

--- a/lib/generatePipeline.ts
+++ b/lib/generatePipeline.ts
@@ -13,6 +13,7 @@ import { generateViaResponses } from "./responsesImageAdapter.js";
 import { generateViaGrok, planGrokImage } from "./grokImageAdapter.js";
 import { generateViaAgy } from "./agyImageAdapter.js";
 import { generateViaGeminiApi } from "./geminiApiImageAdapter.js";
+import { generateViaAtlasCloud } from "./atlasCloudImageAdapter.js";
 import { isNonRetryableGenerationError, normalizeGenerationFailure, type UpstreamErr } from "./generationErrors.js";
 import { startJob, finishJob, registerJobAbortController, isJobCanceled, isStartJobFailure, setJobPhase, INFLIGHT_RETRY_AFTER_SECONDS, } from "./inflight.js";
 import { isGenerationCanceledError, makeGenerationCanceledError, throwIfJobCanceled, } from "./generationCancel.js";
@@ -128,6 +129,13 @@ export async function runGeneratePipeline(req: Request, res: Response, ctx: Runt
           requestId,
         });
       }
+      if (activeProvider === "atlascloud" && providerRefCount > 10) {
+        return fail(400, {
+          error: "Atlas Cloud image editing supports up to 10 reference images",
+          code: "ATLASCLOUD_REF_TOO_MANY",
+          requestId,
+        });
+      }
       const started = startJob({
         requestId,
         kind: "classic",
@@ -193,7 +201,7 @@ export async function runGeneratePipeline(req: Request, res: Response, ctx: Runt
       });
       const startTime = Date.now();
       const mimeMap: Record<string, string> = { png: "image/png", jpeg: "image/jpeg", webp: "image/webp" };
-      const effectiveFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? "jpeg" : String(format);
+      const effectiveFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? "jpeg" : String(format);
       const mime = mimeMap[effectiveFormat] || "image/png";
       await mkdir(ctx.config.storage.generatedDir, { recursive: true });
       const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined;
@@ -225,6 +233,18 @@ export async function runGeneratePipeline(req: Request, res: Response, ctx: Runt
             references: refCheck.refDetails,
             signal: cancelController.signal,
             requestId,
+          });
+          throwIfJobCanceled(requestId);
+          return r;
+        }
+        if (activeProvider === "atlascloud") {
+          const r = await generateViaAtlasCloud(generationPrompt, requireRuntimeContext(ctx), {
+            model: imageModel,
+            size: effectiveSize,
+            quality,
+            signal: cancelController.signal,
+            requestId,
+            references: refCheck.refDetails,
           });
           throwIfJobCanceled(requestId);
           return r;
@@ -300,10 +320,10 @@ export async function runGeneratePipeline(req: Request, res: Response, ctx: Runt
         if (r.status === "fulfilled" && r.value.b64) {
           throwIfJobCanceled(requestId);
           const valueWithMime = r.value as typeof r.value & { mime?: string };
-          const resultMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api"
+          const resultMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud"
             ? (valueWithMime.mime || detectImageMimeFromB64(r.value.b64) || mime)
             : mime;
-          const resultFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? imageFormatFromMime(resultMime) : effectiveFormat;
+          const resultFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? imageFormatFromMime(resultMime) : effectiveFormat;
           const retryValue = r.value as typeof r.value & {
             retryKind?: string;
             initialEventCount?: number;

--- a/lib/imageModels.js
+++ b/lib/imageModels.js
@@ -7,6 +7,11 @@ const GROK_FALLBACK_IMAGE_MODEL = "grok-imagine-image";
 const VALID_GROK_IMAGE_MODELS = new Set(["grok-imagine-image", "grok-imagine-image-quality"]);
 const GEMINI_API_FALLBACK_IMAGE_MODEL = "nano-banana-2";
 const VALID_GEMINI_API_MODELS = new Set(["nano-banana-2", "nano-banana-pro"]);
+const ATLASCLOUD_FALLBACK_IMAGE_MODEL = "openai/gpt-image-2/text-to-image";
+const VALID_ATLASCLOUD_IMAGE_MODELS = new Set([
+    "openai/gpt-image-2/text-to-image",
+    "openai/gpt-image-2/edit",
+]);
 export function normalizeReasoningEffort(ctx, rawEffort) {
     const configured = ctx?.config?.imageModels;
     const fallback = configured?.reasoningEffort ?? FALLBACK_REASONING_EFFORT;
@@ -68,6 +73,19 @@ export function normalizeGeminiApiModel(rawModel) {
         return {
             error: `Gemini API image model must be one of: ${[...VALID_GEMINI_API_MODELS].join(", ")}`,
             code: "INVALID_GEMINI_API_IMAGE_MODEL",
+            status: 400,
+        };
+    }
+    return { model: rawModel };
+}
+export function normalizeAtlasCloudImageModel(rawModel) {
+    if (typeof rawModel !== "string" || rawModel.length === 0) {
+        return { model: ATLASCLOUD_FALLBACK_IMAGE_MODEL };
+    }
+    if (!VALID_ATLASCLOUD_IMAGE_MODELS.has(rawModel)) {
+        return {
+            error: `Atlas Cloud image model must be one of: ${[...VALID_ATLASCLOUD_IMAGE_MODELS].join(", ")}`,
+            code: "INVALID_ATLASCLOUD_IMAGE_MODEL",
             status: 400,
         };
     }

--- a/lib/imageModels.ts
+++ b/lib/imageModels.ts
@@ -11,6 +11,11 @@ const VALID_GROK_IMAGE_MODELS = new Set(["grok-imagine-image", "grok-imagine-ima
 
 const GEMINI_API_FALLBACK_IMAGE_MODEL = "nano-banana-2";
 const VALID_GEMINI_API_MODELS = new Set(["nano-banana-2", "nano-banana-pro"]);
+const ATLASCLOUD_FALLBACK_IMAGE_MODEL = "openai/gpt-image-2/text-to-image";
+const VALID_ATLASCLOUD_IMAGE_MODELS = new Set([
+  "openai/gpt-image-2/text-to-image",
+  "openai/gpt-image-2/edit",
+]);
 
 export function normalizeReasoningEffort(ctx: RouteRuntimeContext | null | undefined, rawEffort: unknown) {
   const configured = (ctx?.config as { imageModels?: { reasoningEffort?: string; validReasoningEfforts?: Set<string> } } | undefined)?.imageModels;
@@ -81,6 +86,20 @@ export function normalizeGeminiApiModel(rawModel: unknown) {
     return {
       error: `Gemini API image model must be one of: ${[...VALID_GEMINI_API_MODELS].join(", ")}`,
       code: "INVALID_GEMINI_API_IMAGE_MODEL" as const,
+      status: 400 as const,
+    };
+  }
+  return { model: rawModel };
+}
+
+export function normalizeAtlasCloudImageModel(rawModel: unknown) {
+  if (typeof rawModel !== "string" || rawModel.length === 0) {
+    return { model: ATLASCLOUD_FALLBACK_IMAGE_MODEL };
+  }
+  if (!VALID_ATLASCLOUD_IMAGE_MODELS.has(rawModel)) {
+    return {
+      error: `Atlas Cloud image model must be one of: ${[...VALID_ATLASCLOUD_IMAGE_MODELS].join(", ")}`,
+      code: "INVALID_ATLASCLOUD_IMAGE_MODEL" as const,
       status: 400 as const,
     };
   }

--- a/lib/multimodePipeline.ts
+++ b/lib/multimodePipeline.ts
@@ -12,6 +12,7 @@ import { generateMultimodeViaResponses } from "./responsesImageAdapter.js";
 import { generateMultimodeViaGrok } from "./grokMultimodeAdapter.js";
 import { generateViaAgy } from "./agyImageAdapter.js";
 import { generateViaGeminiApi } from "./geminiApiImageAdapter.js";
+import { generateViaAtlasCloud } from "./atlasCloudImageAdapter.js";
 import { startJob, finishJob, registerJobAbortController, isJobCanceled, isStartJobFailure, INFLIGHT_RETRY_AFTER_SECONDS } from "./inflight.js";
 import { isGenerationCanceledError, makeGenerationCanceledError, throwIfJobCanceled, } from "./generationCancel.js";
 import { logEvent, logError } from "./logger.js";
@@ -199,7 +200,7 @@ export async function runMultimodePipeline(req: Request, res: Response, ctx: Run
       logEvent("multimode", "request", { requestId, quality, model: imageModel, size: effectiveSize, moderation, maxImages, refs: refCheck.refs.length, referenceBytes: referencePayload.referenceBytes, promptChars: typeof prompt === "string" ? prompt.length : 0, webSearchEnabled, });
       const startTime = Date.now();
       const mimeMap: Record<string, string> = { png: "image/png", jpeg: "image/jpeg", webp: "image/webp" };
-      const mmFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? "jpeg" : String(format);
+      const mmFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? "jpeg" : String(format);
       const mime = mimeMap[mmFormat] || "image/png";
       const sequenceId = `seq_${Date.now().toString(36)}_${randomBytes(4).toString("hex")}`;
       routeMaxImages = maxImages;
@@ -219,10 +220,10 @@ export async function runMultimodePipeline(req: Request, res: Response, ctx: Run
       const persistAndSendImage = async ( image: MultimodeImage, index: number, totalReturned: number, status: ReturnType<typeof sequenceStatus>, ) => {
         if (persistedIndexes.has(index)) return;
         throwIfJobCanceled(requestId);
-        const resultMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api"
+        const resultMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud"
           ? (image.mime || detectImageMimeFromB64(image.b64) || mime)
           : mime;
-        const resultFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? imageFormatFromMime(resultMime) : mmFormat;
+        const resultFormat = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? imageFormatFromMime(resultMime) : mmFormat;
         const rand = randomBytes(ctx.config.ids.generatedHexBytes).toString("hex");
         const filename = `${Date.now()}_${rand}_multimode_${index}.${resultFormat}`;
         const createdAt = Date.now();
@@ -300,6 +301,20 @@ export async function runMultimodePipeline(req: Request, res: Response, ctx: Run
           references: refCheck.refDetails,
           signal: cancelController.signal,
           requestId,
+        });
+        generated = {
+          images: [{ b64: r.b64, revisedPrompt: r.revisedPrompt }],
+          usage: r.usage,
+          webSearchCalls: r.webSearchCalls,
+        };
+      } else if (activeProvider === "atlascloud") {
+        const r = await generateViaAtlasCloud(prompt, requireRuntimeContext(ctx), {
+          model: imageModel,
+          size: effectiveSize,
+          quality: routeQuality,
+          signal: cancelController.signal,
+          requestId,
+          references: refCheck.refDetails,
         });
         generated = {
           images: [{ b64: r.b64, revisedPrompt: r.revisedPrompt }],

--- a/lib/nodeGeneration.ts
+++ b/lib/nodeGeneration.ts
@@ -11,6 +11,7 @@ import { generateViaResponses, editViaResponses } from "./responsesImageAdapter.
 import { generateViaGrok } from "./grokImageAdapter.js";
 import { generateViaAgy } from "./agyImageAdapter.js";
 import { generateViaGeminiApi } from "./geminiApiImageAdapter.js";
+import { generateViaAtlasCloud } from "./atlasCloudImageAdapter.js";
 import { isNonRetryableGenerationError, normalizeGenerationFailure, type UpstreamErr } from "./generationErrors.js";
 import { logEvent, logError } from "./logger.js";
 import { errInfo } from "./errInfo.js";
@@ -135,6 +136,18 @@ export async function runNodeGeneration(req: Request, res: Response, ctx: Runtim
           parentNodeId,
         });
       }
+      if (activeProvider === "atlascloud" && inputImageCount > 10) {
+        finishStatus = "error";
+        finishHttpStatus = 400;
+        return res.status(400).json({
+          error: {
+            code: "ATLASCLOUD_REF_TOO_MANY",
+            message: "Atlas Cloud image editing supports up to 10 reference images.",
+          },
+          code: "ATLASCLOUD_REF_TOO_MANY",
+          parentNodeId,
+        });
+      }
       const started = startJob({
         requestId,
         kind: "node",
@@ -208,7 +221,7 @@ export async function runNodeGeneration(req: Request, res: Response, ctx: Runtim
       }
       let b64: string | undefined, usage: unknown, webSearchCalls = 0, revisedPrompt: string | null = null;
       const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined;
-      let resultFormat: "png" | "jpeg" | "webp" = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? "jpeg" : format as "png" | "jpeg" | "webp";
+      let resultFormat: "png" | "jpeg" | "webp" = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? "jpeg" : format as "png" | "jpeg" | "webp";
       const maxAttempts = inputImageCount > 0 ? 1 : 2;
       let lastErr: UpstreamErr | null = null;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -248,6 +261,17 @@ export async function runNodeGeneration(req: Request, res: Response, ctx: Runtim
                   : undefined,
                 signal: cancelController.signal,
                 requestId,
+              })
+            : activeProvider === "atlascloud"
+            ? await generateViaAtlasCloud(parentB64 ? `Edit this image: ${prompt}` : prompt, requireRuntimeContext(ctx), {
+                model: effectiveImageModel,
+                size: effectiveSize,
+                quality,
+                signal: cancelController.signal,
+                requestId,
+                references: parentB64
+                  ? [{ b64: parentB64, declaredMime: null, detectedMime: null }, ...((refCheck.refDetails || []) as any[])]
+                  : refCheck.refDetails,
               })
             : activeProvider === "grok" || activeProvider === "grok-api"
             ? await generateViaGrok(prompt, ctx, {
@@ -299,7 +323,7 @@ export async function runNodeGeneration(req: Request, res: Response, ctx: Runtim
             usage = r.usage;
             webSearchCalls = r.webSearchCalls || 0;
             revisedPrompt = r.revisedPrompt || null;
-            if (activeProvider === "grok" || activeProvider === "grok-api" || activeProvider === "gemini-api") {
+            if (activeProvider === "grok" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud") {
               resultFormat = imageFormatFromMime(("mime" in r ? r.mime : undefined) || detectImageMimeFromB64(r.b64) || "image/jpeg");
             }
             break;

--- a/lib/providerOptions.ts
+++ b/lib/providerOptions.ts
@@ -1,5 +1,5 @@
 import type { RuntimeContext } from "./runtimeContext.js";
-import { normalizeImageModel, normalizeReasoningEffort, normalizeGrokImageModel, normalizeGeminiApiModel } from "./imageModels.js";
+import { normalizeImageModel, normalizeReasoningEffort, normalizeGrokImageModel, normalizeGeminiApiModel, normalizeAtlasCloudImageModel } from "./imageModels.js";
 
 export function resolveProviderOptions(ctx: RuntimeContext | null | undefined, {
   provider = "oauth",
@@ -25,6 +25,18 @@ export function resolveProviderOptions(ctx: RuntimeContext | null | undefined, {
     return {
       provider: "gemini-api" as const,
       model: geminiModelCheck.model,
+      reasoningEffort: "none",
+      size: rawSize || "1024x1024",
+      webSearchEnabled: false,
+    };
+  }
+
+  if (provider === "atlascloud") {
+    const atlasModelCheck = normalizeAtlasCloudImageModel(rawModel || "openai/gpt-image-2/text-to-image");
+    if (atlasModelCheck.error) return { error: atlasModelCheck.error, code: atlasModelCheck.code, status: atlasModelCheck.status };
+    return {
+      provider: "atlascloud" as const,
+      model: atlasModelCheck.model,
       reasoningEffort: "none",
       size: rawSize || "1024x1024",
       webSearchEnabled: false,

--- a/lib/runtimeContext.ts
+++ b/lib/runtimeContext.ts
@@ -31,6 +31,9 @@ export interface RuntimeContext {
   geminiApiKey: string | undefined;
   geminiApiKeySource: ApiKeySource;
   hasGeminiApiKey: boolean;
+  atlasCloudApiKey: string | undefined;
+  atlasCloudApiKeySource: ApiKeySource;
+  hasAtlasCloudApiKey: boolean;
   vertexServiceAccountJson: string | undefined;
   vertexProjectId: string | undefined;
   hasVertexKey: boolean;
@@ -106,6 +109,9 @@ export function requireRuntimeContext(ctx: RouteRuntimeContext | undefined): Run
   if (target.geminiApiKey === undefined && !Object.prototype.hasOwnProperty.call(target, 'geminiApiKey')) target.geminiApiKey = undefined;
   if (target.hasGeminiApiKey === undefined) target.hasGeminiApiKey = false;
   if (target.geminiApiKeySource === undefined) target.geminiApiKeySource = undefined;
+  if (target.atlasCloudApiKey === undefined && !Object.prototype.hasOwnProperty.call(target, 'atlasCloudApiKey')) target.atlasCloudApiKey = undefined;
+  if (target.hasAtlasCloudApiKey === undefined) target.hasAtlasCloudApiKey = false;
+  if (target.atlasCloudApiKeySource === undefined) target.atlasCloudApiKeySource = undefined;
   if (target.vertexServiceAccountJson === undefined && !Object.prototype.hasOwnProperty.call(target, 'vertexServiceAccountJson')) target.vertexServiceAccountJson = undefined;
   if (target.vertexProjectId === undefined) target.vertexProjectId = undefined;
   if (target.hasVertexKey === undefined) target.hasVertexKey = false;
@@ -166,6 +172,9 @@ export function createTestRuntimeContext(over: RuntimeContextOverrides = {}): Ru
     geminiApiKey: undefined,
     geminiApiKeySource: undefined,
     hasGeminiApiKey: false,
+    atlasCloudApiKey: undefined,
+    atlasCloudApiKeySource: undefined,
+    hasAtlasCloudApiKey: false,
     vertexServiceAccountJson: undefined,
     vertexProjectId: undefined,
     hasVertexKey: false,

--- a/routes/edit.ts
+++ b/routes/edit.ts
@@ -12,6 +12,7 @@ import { editViaResponses } from "../lib/responsesImageAdapter.js";
 import { editViaGrok } from "../lib/grokImageAdapter.js";
 import { generateViaAgy } from "../lib/agyImageAdapter.js";
 import { generateViaGeminiApi } from "../lib/geminiApiImageAdapter.js";
+import { generateViaAtlasCloud } from "../lib/atlasCloudImageAdapter.js";
 import { startJob, finishJob, registerJobAbortController, isJobCanceled, isStartJobFailure, INFLIGHT_RETRY_AFTER_SECONDS } from "../lib/inflight.js";
 import {
   isGenerationCanceledError,
@@ -176,11 +177,12 @@ export function registerEditRoutes(app: Express, ctxRaw: RouteRuntimeContext) {
         finishErrorCode = "INVALID_EDIT_INPUT";
         return res.status(400).json({ error: "Prompt and image are required" });
       }
-      if ((activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api") && rawMask) {
+      if ((activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud") && rawMask) {
         finishStatus = "error";
         finishHttpStatus = 400;
-        const code = activeProvider === "agy" ? "AGY_MASK_UNSUPPORTED" : activeProvider === "gemini-api" ? "GEMINI_API_MASK_UNSUPPORTED" : "GROK_MASK_UNSUPPORTED";
-        return res.status(400).json({ error: `${activeProvider === "agy" ? "Agy" : activeProvider === "gemini-api" ? "Gemini API" : "Grok"} provider does not support mask editing`, code });
+        const code = activeProvider === "agy" ? "AGY_MASK_UNSUPPORTED" : activeProvider === "gemini-api" ? "GEMINI_API_MASK_UNSUPPORTED" : activeProvider === "atlascloud" ? "ATLASCLOUD_MASK_UNSUPPORTED" : "GROK_MASK_UNSUPPORTED";
+        const label = activeProvider === "agy" ? "Agy" : activeProvider === "gemini-api" ? "Gemini API" : activeProvider === "atlascloud" ? "Atlas Cloud" : "Grok";
+        return res.status(400).json({ error: `${label} provider does not support mask editing`, code });
       }
       const maskCheck: any = validateEditMask(imageB64, rawMask);
       if (maskCheck.error) {
@@ -245,6 +247,21 @@ export function registerEditRoutes(app: Express, ctxRaw: RouteRuntimeContext) {
         revisedPrompt = r.revisedPrompt;
         webSearchCalls = r.webSearchCalls;
         resultMimeFromProvider = r.mime;
+      } else if (activeProvider === "atlascloud") {
+        const r = await generateViaAtlasCloud(`Edit this image: ${prompt}`, requireRuntimeContext(ctx), {
+          model: imageModel,
+          size: effectiveSize,
+          quality,
+          signal: cancelController.signal,
+          requestId,
+          references: [{ b64: imageB64, declaredMime: null, detectedMime: detectImageMimeFromB64(imageB64) || null }],
+        });
+        resultB64 = r.b64;
+        providerUrl = r.providerUrl ?? null;
+        usage = r.usage;
+        revisedPrompt = r.revisedPrompt ?? undefined;
+        webSearchCalls = r.webSearchCalls;
+        resultMimeFromProvider = r.mime;
       } else if (activeProvider === "grok" || activeProvider === "grok-api") {
         const directApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined;
         const grokModel = quality === "high" ? "grok-imagine-image-quality" : imageModel;
@@ -290,10 +307,10 @@ export function registerEditRoutes(app: Express, ctxRaw: RouteRuntimeContext) {
       const elapsed = +((Date.now() - startTime) / 1000).toFixed(1);
       await mkdir(ctx.config.storage.generatedDir, { recursive: true });
       throwIfJobCanceled(requestId);
-      const editMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api"
+      const editMime = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud"
         ? (resultMimeFromProvider || detectImageMimeFromB64(resultB64) || "image/png")
         : "image/png";
-      const editExt = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" ? imageFormatFromMime(editMime) : "png";
+      const editExt = activeProvider === "grok" || activeProvider === "agy" || activeProvider === "grok-api" || activeProvider === "gemini-api" || activeProvider === "atlascloud" ? imageFormatFromMime(editMime) : "png";
       const filename = `${Date.now()}_${randomBytes(ctx.config.ids.generatedHexBytes).toString("hex")}.${editExt}`;
       const editBuffer = Buffer.from(resultB64, "base64");
       const editFilePath = join(ctx.config.storage.generatedDir, filename);

--- a/routes/keys.ts
+++ b/routes/keys.ts
@@ -33,28 +33,31 @@ async function updateConfigFile(
   });
 }
 
-type KeyProvider = "openai" | "xai" | "gemini";
+type KeyProvider = "openai" | "xai" | "gemini" | "atlascloud";
 
 const KEY_PREFIX_MAP: Record<KeyProvider, string[]> = {
   openai: ["sk-"],
   xai: ["xai-"],
   gemini: ["AI"],
+  atlascloud: ["apikey-"],
 };
 
 const VALIDATE_URL_MAP: Record<KeyProvider, string> = {
   openai: "https://api.openai.com/v1/models",
   xai: "https://api.x.ai/v1/models",
   gemini: "https://generativelanguage.googleapis.com/v1beta/models",
+  atlascloud: "https://api.atlascloud.ai/api/v1/models",
 };
 
 const CONFIG_KEY_MAP: Record<KeyProvider, string> = {
   openai: "apiKey",
   xai: "xaiApiKey",
   gemini: "geminiApiKey",
+  atlascloud: "atlasCloudApiKey",
 };
 
 function isKeyProvider(v: string): v is KeyProvider {
-  return v === "openai" || v === "xai" || v === "gemini";
+  return v === "openai" || v === "xai" || v === "gemini" || v === "atlascloud";
 }
 
 function maskKey(key: string): string {
@@ -66,13 +69,14 @@ function keySourceForProvider(ctx: RuntimeContext, provider: KeyProvider): { key
   if (provider === "openai") return { key: ctx.apiKey, source: ctx.apiKeySource || "none" };
   if (provider === "xai") return { key: ctx.xaiApiKey, source: ctx.xaiApiKeySource || "none" };
   if (provider === "gemini") return { key: ctx.geminiApiKey, source: ctx.geminiApiKeySource || "none" };
+  if (provider === "atlascloud") return { key: ctx.atlasCloudApiKey, source: ctx.atlasCloudApiKeySource || "none" };
   return { key: undefined, source: "none" };
 }
 
 export function mountKeyRoutes(app: Express, ctx: RuntimeContext) {
   app.get("/api/keys/status", (_req: Request, res: Response) => {
     const status: Record<string, unknown> = {};
-    for (const provider of ["openai", "xai", "gemini"] as const) {
+    for (const provider of ["openai", "xai", "gemini", "atlascloud"] as const) {
       const { key, source } = keySourceForProvider(ctx, provider);
       status[provider] = {
         configured: !!key,
@@ -246,6 +250,10 @@ export function mountKeyRoutes(app: Express, ctx: RuntimeContext) {
       (ctx as any).geminiApiKeySource = "config";
       (ctx as any).hasGeminiApiKey = true;
       (ctx as any).geminiAuthMode = "apikey";
+    } else if (provider === "atlascloud") {
+      (ctx as any).atlasCloudApiKey = trimmed;
+      (ctx as any).atlasCloudApiKeySource = "config";
+      (ctx as any).hasAtlasCloudApiKey = true;
     }
 
     return res.json({ ok: true, provider, source: "config", valid: true });
@@ -279,6 +287,10 @@ export function mountKeyRoutes(app: Express, ctx: RuntimeContext) {
       (ctx as any).geminiApiKey = undefined;
       (ctx as any).geminiApiKeySource = "none";
       (ctx as any).hasGeminiApiKey = false;
+    } else if (provider === "atlascloud") {
+      (ctx as any).atlasCloudApiKey = undefined;
+      (ctx as any).atlasCloudApiKeySource = "none";
+      (ctx as any).hasAtlasCloudApiKey = false;
     }
 
     return res.json({ ok: true, provider, removed: true });

--- a/server.ts
+++ b/server.ts
@@ -96,6 +96,24 @@ async function loadGeminiApiKey(): Promise<ApiKeyLoadResult> {
   return { apiKey: null, apiKeySource: "none" };
 }
 
+async function loadAtlasCloudApiKey(): Promise<ApiKeyLoadResult> {
+  if (process.env.ATLASCLOUD_API_KEY) {
+    return { apiKey: process.env.ATLASCLOUD_API_KEY, apiKeySource: "env" };
+  }
+  const candidates = [
+    config.storage.configFile,
+    join(rootDir, ".ima2", "config.json"),
+  ];
+  for (const cfgPath of candidates) {
+    if (!existsSync(cfgPath)) continue;
+    try {
+      const cfg = JSON.parse(await readFile(cfgPath, "utf-8")) as { atlasCloudApiKey?: string };
+      if (cfg.atlasCloudApiKey) return { apiKey: cfg.atlasCloudApiKey, apiKeySource: "config" };
+    } catch {}
+  }
+  return { apiKey: null, apiKeySource: "none" };
+}
+
 type VertexKeyLoadResult = { json: string | null; projectId: string | null; source: ApiKeySource };
 
 async function loadVertexKey(): Promise<VertexKeyLoadResult> {
@@ -304,6 +322,7 @@ export async function createRuntimeContext(overrides: StartServerOverrides = {})
       : await loadApiKey();
   const loadedXaiKey = await loadXaiApiKey();
   const loadedGeminiKey = await loadGeminiApiKey();
+  const loadedAtlasCloudKey = await loadAtlasCloudApiKey();
   const loadedVertexKey = await loadVertexKey();
   const geminiAuthMode = await loadGeminiAuthMode();
   const apiKey = loadedKey.apiKey;
@@ -339,6 +358,9 @@ export async function createRuntimeContext(overrides: StartServerOverrides = {})
     geminiApiKey: loadedGeminiKey.apiKey ?? undefined,
     geminiApiKeySource: loadedGeminiKey.apiKeySource as ApiKeySource,
     hasGeminiApiKey: !!loadedGeminiKey.apiKey,
+    atlasCloudApiKey: loadedAtlasCloudKey.apiKey ?? undefined,
+    atlasCloudApiKeySource: loadedAtlasCloudKey.apiKeySource as ApiKeySource,
+    hasAtlasCloudApiKey: !!loadedAtlasCloudKey.apiKey,
     vertexServiceAccountJson: loadedVertexKey.json ?? undefined,
     vertexProjectId: loadedVertexKey.projectId ?? undefined,
     hasVertexKey: !!loadedVertexKey.json,

--- a/tests/atlascloud-provider-contract.test.ts
+++ b/tests/atlascloud-provider-contract.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateViaAtlasCloud } from "../lib/atlasCloudImageAdapter.ts";
+import { resolveProviderOptions } from "../lib/providerOptions.ts";
+import { createTestRuntimeContext } from "../lib/runtimeContext.ts";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("atlascloud provider options normalize model and disable unsupported controls", () => {
+  const resolved = resolveProviderOptions(createTestRuntimeContext(), {
+    provider: "atlascloud",
+    rawModel: "openai/gpt-image-2/text-to-image",
+    rawReasoningEffort: "high",
+    rawWebSearchEnabled: true,
+    rawSize: "1792x1024",
+  });
+
+  assert.equal(resolved.provider, "atlascloud");
+  assert.equal(resolved.model, "openai/gpt-image-2/text-to-image");
+  assert.equal(resolved.reasoningEffort, "none");
+  assert.equal(resolved.webSearchEnabled, false);
+  assert.equal(resolved.size, "1792x1024");
+});
+
+test("atlascloud adapter requires ATLASCLOUD_API_KEY", async () => {
+  await assert.rejects(
+    () => generateViaAtlasCloud("city skyline", createTestRuntimeContext()),
+    (err: any) => err?.code === "ATLASCLOUD_API_KEY_MISSING" && err?.status === 401,
+  );
+});
+
+test("atlascloud adapter submits text-to-image requests and downloads output", async () => {
+  const calls: Array<{ url: string; body?: any }> = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = init?.body && typeof init.body === "string" ? JSON.parse(init.body) : undefined;
+    calls.push({ url, body });
+
+    if (url.endsWith("/model/generateImage")) {
+      return Response.json({ data: { id: "pred_1" } });
+    }
+    if (url.endsWith("/model/result/pred_1")) {
+      return Response.json({ data: { status: "completed", outputs: [{ url: "https://cdn.example/out.jpg" }] } });
+    }
+    if (url === "https://cdn.example/out.jpg") {
+      return new Response(Buffer.from("fake image"), { headers: { "content-type": "image/jpeg" } });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+
+  const result = await generateViaAtlasCloud("city skyline", createTestRuntimeContext({ atlasCloudApiKey: "ak-test" }), {
+    model: "openai/gpt-image-2/text-to-image",
+    size: "1024x1024",
+    quality: "high",
+  });
+
+  assert.equal(calls[0].url, "https://api.atlascloud.ai/api/v1/model/generateImage");
+  assert.deepEqual(calls[0].body, {
+    model: "openai/gpt-image-2/text-to-image",
+    prompt: "city skyline",
+    size: "1024x1024",
+    quality: "high",
+    output_format: "jpeg",
+    enable_base64_output: false,
+    enable_sync_mode: false,
+  });
+  assert.equal(result.b64, Buffer.from("fake image").toString("base64"));
+  assert.equal(result.mime, "image/jpeg");
+  assert.equal(result.providerUrl, "https://cdn.example/out.jpg");
+});
+
+test("atlascloud adapter uploads references before edit requests", async () => {
+  const generatedBodies: any[] = [];
+  const urls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    urls.push(url);
+
+    if (url.endsWith("/model/uploadMedia")) {
+      assert.ok(init?.body instanceof FormData);
+      return Response.json({ data: { url: "https://media.example/ref.png" } });
+    }
+    if (url.endsWith("/model/generateImage")) {
+      generatedBodies.push(JSON.parse(String(init?.body)));
+      return Response.json({ data: { request_id: "pred_edit" } });
+    }
+    if (url.endsWith("/model/result/pred_edit")) {
+      return Response.json({ data: { status: "succeeded", result: "data:image/png;base64,b3V0" } });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+
+  const result = await generateViaAtlasCloud("make it brighter", createTestRuntimeContext({ atlasCloudApiKey: "ak-test" }), {
+    references: [{ b64: Buffer.from("ref").toString("base64"), declaredMime: "image/png" }],
+  });
+
+  assert.deepEqual(generatedBodies[0].images, ["https://media.example/ref.png"]);
+  assert.equal(generatedBodies[0].model, "openai/gpt-image-2/edit");
+  assert.equal(result.b64, "b3V0");
+  assert.equal(result.mime, "image/png");
+  assert.deepEqual(urls.slice(0, 3), [
+    "https://api.atlascloud.ai/api/v1/model/uploadMedia",
+    "https://api.atlascloud.ai/api/v1/model/generateImage",
+    "https://api.atlascloud.ai/api/v1/model/result/pred_edit",
+  ]);
+});

--- a/tests/cli-capabilities-contract.test.js
+++ b/tests/cli-capabilities-contract.test.js
@@ -27,7 +27,7 @@ describe("CLI capabilities contract", () => {
     assert.match(src, /moderation:\s*toArray\(appConfig\.oauth\.validModeration\)/);
     assert.match(src, /modes:\s*\[\.\.\.VALID_MODES\]/);
     assert.match(src, /providers:\s*\[\.\.\.VALID_PROVIDERS\]/);
-    assert.match(src, /const VALID_PROVIDERS = \["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"\]/);
+    assert.match(src, /const VALID_PROVIDERS = \["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"\]/);
     assert.match(src, /"grok status"/);
     assert.match(src, /"prompt build"/);
     assert.match(src, /configKeys:/);

--- a/tests/cli-feature-parity-contract.test.js
+++ b/tests/cli-feature-parity-contract.test.js
@@ -11,10 +11,10 @@ describe("CLI feature parity contract", () => {
     const src = readSource("bin/commands/gen.ts");
 
     assert.match(src, /provider:\s*\{\s*type:\s*"string"\s*\}/);
-    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"\]\)/);
-    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api>/);
+    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"\]\)/);
+    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api\|atlascloud>/);
     assert.match(src, /nano-banana-2\|nano-banana-pro/);
-    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api/);
+    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud/);
     assert.match(src, /if \(args\.provider\) body\.provider = args\.provider/);
     assert.match(src, /body\.webSearchEnabled = false/);
     assert.match(src, /body\.webSearchEnabled = true/);
@@ -25,10 +25,10 @@ describe("CLI feature parity contract", () => {
     const docs = readSource("docs/CLI.md");
 
     assert.match(src, /provider:\s*\{\s*type:\s*"string"\s*\}/);
-    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"\]\)/);
-    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api>/);
+    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"\]\)/);
+    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api\|atlascloud>/);
     assert.match(src, /nano-banana-2\|nano-banana-pro/);
-    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api/);
+    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud/);
     assert.match(src, /if \(args\.provider\) editBody\.provider = args\.provider/);
     assert.match(src, /editBody\.webSearchEnabled = false/);
     assert.match(src, /editBody\.webSearchEnabled = true/);
@@ -42,11 +42,11 @@ describe("CLI feature parity contract", () => {
 
     assert.match(src, /fileToDataUri/);
     assert.match(src, /provider:\s*\{\s*type:\s*"string"\s*\}/);
-    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api>/);
+    assert.match(src, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api\|atlascloud>/);
     assert.match(src, /nano-banana-2\|nano-banana-pro/);
     assert.match(src, /mode:\s*\{\s*type:\s*"string",\s*default:\s*"auto"\s*\}/);
     assert.match(src, /ref:\s*\{\s*type:\s*"string",\s*repeatable:\s*true\s*\}/);
-    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"\]\)/);
+    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"\]\)/);
     assert.match(src, /VALID_MODES = new Set\(\["auto", "direct"\]\)/);
     assert.match(src, /MAX_REFERENCE_COUNT/);
     assert.match(src, /refs\.length > MAX_REFERENCE_COUNT/);
@@ -62,8 +62,8 @@ describe("CLI feature parity contract", () => {
     const src = readSource("bin/commands/node.ts");
 
     assert.match(src, /provider:\s*\{\s*type:\s*"string"\s*\}/);
-    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api"\]\)/);
-    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api/);
+    assert.match(src, /VALID_PROVIDERS = new Set\(\["auto", "oauth", "api", "grok", "grok-api", "agy", "gemini-api", "atlascloud"\]\)/);
+    assert.match(src, /--provider must be one of: auto, oauth, api, grok, grok-api, agy, gemini-api, atlascloud/);
     assert.match(src, /if \(args\.provider\) body\.provider = args\.provider/);
     assert.match(src, /body\.webSearchEnabled = false/);
     assert.match(src, /body\.webSearchEnabled = true/);
@@ -89,7 +89,7 @@ describe("CLI feature parity contract", () => {
   it("public CLI docs describe provider semantics and multimode parity", () => {
     const docs = readSource("docs/CLI.md");
 
-    assert.match(docs, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api>/);
+    assert.match(docs, /--provider <auto\|oauth\|api\|grok\|grok-api\|agy\|gemini-api\|atlascloud>/);
     assert.match(docs, /api` forces the API-key Responses path/);
     assert.match(docs, /oauth` forces the local OAuth proxy path/);
     assert.match(docs, /auto` preserves route default behavior/);

--- a/ui/src/components/AccountSettings.tsx
+++ b/ui/src/components/AccountSettings.tsx
@@ -180,6 +180,15 @@ export function AccountSettings() {
                 configured={keyStatus.xai?.configured ?? false}
                 onSaved={mutateKeys}
               />
+              <ApiKeyInput
+                provider="atlascloud"
+                label={t("settings.apiKeys.atlascloud.label")}
+                placeholder={t("settings.apiKeys.atlascloud.placeholder")}
+                maskedKey={keyStatus.atlascloud?.maskedKey ?? null}
+                source={keyStatus.atlascloud?.source ?? "none"}
+                configured={keyStatus.atlascloud?.configured ?? false}
+                onSaved={mutateKeys}
+              />
               <GeminiKeySection
                 keyStatus={keyStatus}
                 onSaved={mutateKeys}

--- a/ui/src/components/ApiKeyInput.tsx
+++ b/ui/src/components/ApiKeyInput.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { useI18n } from "../i18n";
 
 type ApiKeyInputProps = {
-  provider: "openai" | "xai" | "gemini";
+  provider: "openai" | "xai" | "gemini" | "atlascloud";
   label: string;
   placeholder: string;
   maskedKey: string | null;

--- a/ui/src/components/ProviderSelect.tsx
+++ b/ui/src/components/ProviderSelect.tsx
@@ -48,6 +48,7 @@ export function useProviderAvailability(): Record<Provider, ProviderAvailability
 
   const xaiKeyOk = keyStatus?.xai?.valid === true;
   const geminiKeyOk = keyStatus?.gemini?.valid === true || keyStatus?.vertex?.valid === true;
+  const atlasCloudKeyOk = keyStatus?.atlascloud?.valid === true;
 
   return {
     oauth: { ok: oauthReady, reason: oauthReason, hint: oauthHint },
@@ -71,6 +72,10 @@ export function useProviderAvailability(): Record<Provider, ProviderAvailability
     "gemini-api": {
       ok: geminiKeyOk,
       reason: geminiKeyOk ? "" : t("provider.geminiApiKeyRequired"),
+    },
+    atlascloud: {
+      ok: atlasCloudKeyOk,
+      reason: atlasCloudKeyOk ? "" : t("provider.atlasCloudApiKeyRequired"),
     },
   };
 }
@@ -105,6 +110,12 @@ const GRID: { header: string; cells: CellDef[] }[] = [
     cells: [
       { value: "agy", label: "agy" },
       { value: "gemini-api", label: "API" },
+    ],
+  },
+  {
+    header: "Atlas",
+    cells: [
+      { value: "atlascloud", label: "API" },
     ],
   },
 ];

--- a/ui/src/components/ResultMetadataModal.tsx
+++ b/ui/src/components/ResultMetadataModal.tsx
@@ -23,6 +23,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   "grok-api": "Grok API key",
   agy: "Antigravity Gemini CLI",
   "gemini-api": "Gemini API / Vertex",
+  atlascloud: "Atlas Cloud API",
 };
 
 function present(value: unknown): value is string | number | boolean {

--- a/ui/src/components/home/HomePromptComposer.tsx
+++ b/ui/src/components/home/HomePromptComposer.tsx
@@ -10,6 +10,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   "grok-api": "Grok API",
   agy: "Antigravity",
   "gemini-api": "Gemini API",
+  atlascloud: "Atlas Cloud",
 };
 
 export function HomePromptComposer() {

--- a/ui/src/hooks/useKeyStatus.ts
+++ b/ui/src/hooks/useKeyStatus.ts
@@ -7,7 +7,7 @@ interface KeyStatusEntry {
   maskedKey: string | null;
 }
 
-export type KeyStatus = Record<"openai" | "xai" | "gemini" | "vertex", KeyStatusEntry> & {
+export type KeyStatus = Record<"openai" | "xai" | "gemini" | "atlascloud" | "vertex", KeyStatusEntry> & {
   geminiAuthMode?: "apikey" | "vertex";
 };
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -636,6 +636,7 @@
     "unavailableSr": "(unavailable)",
     "xaiApiKeyRequired": "xAI API key required",
     "geminiApiKeyRequired": "Gemini API key required",
+    "atlasCloudApiKeyRequired": "Atlas Cloud API key required",
     "comingSoon": "Coming soon",
     "agyCompatTitle": "Gemini (agy)",
     "agyCompatBody": "1024x1024 fixed, JPEG output, max 3 refs. No quality/size control.",
@@ -1094,6 +1095,8 @@
       "nanoBanana2": "Nano Banana 2",
       "nanoBanana2Api": "Nano Banana 2",
       "nanoBananaPro": "Nano Banana Pro",
+      "atlasCloudGptImage2": "Atlas Cloud GPT Image 2",
+      "atlasCloudGptImage2Edit": "Atlas Cloud GPT Image 2 Edit",
       "agy": "Antigravity (agy)",
       "gpt53CodexSpark": "GPT-5.3 Codex Spark — unsupported for images",
       "unsupportedHelp": "Grok models use xAI's Images API through the bundled local proxy. GPT models use OpenAI Responses image generation."
@@ -1113,6 +1116,10 @@
       "gemini": {
         "label": "Gemini (Google)",
         "placeholder": "Paste your Gemini API key (AI...)"
+      },
+      "atlascloud": {
+        "label": "Atlas Cloud",
+        "placeholder": "Paste your Atlas Cloud API key (apikey-...)"
       },
       "vertex": {
         "label": "Vertex AI (Service Account)",

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -636,6 +636,7 @@
     "unavailableSr": "(사용 불가)",
     "xaiApiKeyRequired": "xAI API 키 필요",
     "geminiApiKeyRequired": "Gemini API 키 필요",
+    "atlasCloudApiKeyRequired": "Atlas Cloud API 키 필요",
     "comingSoon": "준비 중",
     "agyCompatTitle": "Gemini (agy)",
     "agyCompatBody": "1024x1024 고정, JPEG 출력, 최대 3개 참조. 품질/크기 조절 없음.",
@@ -1094,6 +1095,8 @@
       "nanoBanana2": "Nano Banana 2",
       "nanoBanana2Api": "Nano Banana 2",
       "nanoBananaPro": "나노 바나나 Pro",
+      "atlasCloudGptImage2": "Atlas Cloud GPT Image 2",
+      "atlasCloudGptImage2Edit": "Atlas Cloud GPT Image 2 Edit",
       "agy": "Antigravity (agy)",
       "gpt53CodexSpark": "GPT-5.3 Codex Spark — 이미지 생성 미지원",
       "unsupportedHelp": "Grok 모델은 번들된 로컬 프록시를 통해 xAI Images API를 사용합니다. GPT 모델은 OpenAI Responses 이미지 생성을 사용합니다."
@@ -1113,6 +1116,10 @@
       "gemini": {
         "label": "Gemini (Google)",
         "placeholder": "Gemini API 키 붙여넣기 (AI...)"
+      },
+      "atlascloud": {
+        "label": "Atlas Cloud",
+        "placeholder": "Atlas Cloud API 키 붙여넣기 (apikey-...)"
       },
       "vertex": {
         "label": "Vertex AI (서비스 계정)",

--- a/ui/src/lib/imageModels.ts
+++ b/ui/src/lib/imageModels.ts
@@ -1,4 +1,4 @@
-import type { ImageModel, OpenAIImageModel, GeminiImageModel, Provider, UnsupportedImageModel, VideoModel } from "../types";
+import type { ImageModel, OpenAIImageModel, GeminiImageModel, AtlasCloudImageModel, Provider, UnsupportedImageModel, VideoModel } from "../types";
 
 export const DEFAULT_IMAGE_MODEL: ImageModel = "gpt-5.4-mini";
 export const IMAGE_MODEL_STORAGE_KEY = "ima2.imageModel";
@@ -20,13 +20,16 @@ export const IMAGE_MODEL_OPTIONS: Array<{
   { value: "nano-banana-2", shortLabel: "nb2 agy", fullLabelKey: "settings.imageModel.nanoBanana2", providerHint: "agy" },
   { value: "nano-banana-2", shortLabel: "nb2 api", fullLabelKey: "settings.imageModel.nanoBanana2Api", providerHint: "gemini-api" },
   { value: "nano-banana-pro", shortLabel: "nbp api", fullLabelKey: "settings.imageModel.nanoBananaPro", providerHint: "gemini-api" },
+  { value: "openai/gpt-image-2/text-to-image", shortLabel: "atlas", fullLabelKey: "settings.imageModel.atlasCloudGptImage2", providerHint: "atlascloud" },
+  { value: "openai/gpt-image-2/edit", shortLabel: "atlas edit", fullLabelKey: "settings.imageModel.atlasCloudGptImage2Edit", providerHint: "atlascloud" },
 ];
 
 const GEMINI_MODEL_VALUES = new Set<string>(["nano-banana-2", "nano-banana-pro"]);
+const ATLASCLOUD_MODEL_VALUES = new Set<string>(["openai/gpt-image-2/text-to-image", "openai/gpt-image-2/edit"]);
 
 export const OPENAI_IMAGE_MODEL_OPTIONS = IMAGE_MODEL_OPTIONS.filter(
   (option): option is { value: OpenAIImageModel; shortLabel: string; fullLabelKey: string } =>
-    !option.value.startsWith("grok-") && !GEMINI_MODEL_VALUES.has(option.value),
+    !option.value.startsWith("grok-") && !GEMINI_MODEL_VALUES.has(option.value) && !ATLASCLOUD_MODEL_VALUES.has(option.value),
 );
 
 export const GROK_IMAGE_MODEL_OPTIONS = IMAGE_MODEL_OPTIONS.filter((option) =>
@@ -36,6 +39,11 @@ export const GROK_IMAGE_MODEL_OPTIONS = IMAGE_MODEL_OPTIONS.filter((option) =>
 export const GEMINI_IMAGE_MODEL_OPTIONS = IMAGE_MODEL_OPTIONS.filter(
   (option): option is { value: GeminiImageModel; shortLabel: string; fullLabelKey: string; providerHint?: Provider } =>
     GEMINI_MODEL_VALUES.has(option.value),
+);
+
+export const ATLASCLOUD_IMAGE_MODEL_OPTIONS = IMAGE_MODEL_OPTIONS.filter(
+  (option): option is { value: AtlasCloudImageModel; shortLabel: string; fullLabelKey: string; providerHint?: Provider } =>
+    ATLASCLOUD_MODEL_VALUES.has(option.value),
 );
 
 export const UNSUPPORTED_IMAGE_MODELS: Array<{
@@ -57,9 +65,14 @@ export function isGeminiImageModel(value: unknown): boolean {
   return typeof value === "string" && GEMINI_MODEL_VALUES.has(value);
 }
 
+export function isAtlasCloudImageModel(value: unknown): boolean {
+  return typeof value === "string" && ATLASCLOUD_MODEL_VALUES.has(value);
+}
+
 export function getImageModelOptionsForProvider(provider: Provider) {
   if (provider === "grok" || provider === "grok-api") return GROK_IMAGE_MODEL_OPTIONS;
   if (provider === "agy" || provider === "gemini-api") return GEMINI_IMAGE_MODEL_OPTIONS;
+  if (provider === "atlascloud") return ATLASCLOUD_IMAGE_MODEL_OPTIONS;
   return OPENAI_IMAGE_MODEL_OPTIONS;
 }
 
@@ -69,6 +82,7 @@ export function getImageModelShortLabel(value: string | null | undefined, provid
     const suffix = provider === "gemini-api" ? "gemini-api" : provider === "agy" ? "agy" : provider || "agy";
     return `${value} ${suffix}`;
   }
+  if (ATLASCLOUD_MODEL_VALUES.has(value)) return provider === "atlascloud" ? "gpt-image-2 atlas" : value;
   return IMAGE_MODEL_OPTIONS.find((option) => option.value === value)?.shortLabel ?? value;
 }
 

--- a/ui/src/store/storeHelpers.ts
+++ b/ui/src/store/storeHelpers.ts
@@ -324,7 +324,7 @@ export function getCustomSizeConfirmation(
   state: AppState,
   continuation: NonNullable<CustomSizeConfirmState>["continuation"],
 ): CustomSizeConfirmState {
-  if (state.provider === "grok" || state.provider === "grok-api" || state.provider === "agy" || state.provider === "gemini-api") return null;
+  if (state.provider === "grok" || state.provider === "grok-api" || state.provider === "agy" || state.provider === "gemini-api" || state.provider === "atlascloud") return null;
   if (state.sizePreset !== "custom") return null;
   const result = normalizeCustomSizePairDetailed(
     state.customW,

--- a/ui/src/store/storePersistence.ts
+++ b/ui/src/store/storePersistence.ts
@@ -319,7 +319,7 @@ export function isModeration(value: unknown): value is Moderation {
 }
 
 export function isProvider(value: unknown): value is Provider {
-  return value === "oauth" || value === "api" || value === "grok" || value === "grok-api" || value === "agy" || value === "gemini-api";
+  return value === "oauth" || value === "api" || value === "grok" || value === "grok-api" || value === "agy" || value === "gemini-api" || value === "atlascloud";
 }
 
 export function isPromptMode(value: unknown): value is "auto" | "direct" {

--- a/ui/src/store/storeSettingsImpl.ts
+++ b/ui/src/store/storeSettingsImpl.ts
@@ -1,6 +1,6 @@
 import type { Provider, Quality, SizePreset, Format, Moderation, ImageModel, Count } from "../types";
 import type { ReasoningEffort } from "../lib/reasoning";
-import { DEFAULT_IMAGE_MODEL, isGrokImageModel, isGeminiImageModel, normalizeVideoModelValue } from "../lib/imageModels";
+import { DEFAULT_IMAGE_MODEL, isGrokImageModel, isGeminiImageModel, isAtlasCloudImageModel, normalizeVideoModelValue } from "../lib/imageModels";
 import { parseRequestedCustomSide } from "../lib/size";
 import { getEffectiveVideoSourceCount } from "../lib/videoSourceCount";
 import {
@@ -29,7 +29,11 @@ export function setProviderImpl(provider: Provider, set: StoreSet, get: StoreGet
     const geminiModel = provider === "gemini-api" ? "nano-banana-pro" : "nano-banana-2";
     saveImageModel(geminiModel);
     set({ provider, imageModel: geminiModel });
-  } else if (provider !== "grok" && provider !== "grok-api" && provider !== "agy" && provider !== "gemini-api" && (isGrokImageModel(currentModel) || isGeminiImageModel(currentModel))) {
+  } else if (provider === "atlascloud" && !isAtlasCloudImageModel(currentModel)) {
+    const atlasModel = "openai/gpt-image-2/text-to-image";
+    saveImageModel(atlasModel);
+    set({ provider, imageModel: atlasModel });
+  } else if (provider !== "grok" && provider !== "grok-api" && provider !== "agy" && provider !== "gemini-api" && provider !== "atlascloud" && (isGrokImageModel(currentModel) || isGeminiImageModel(currentModel) || isAtlasCloudImageModel(currentModel))) {
     set({ provider, imageModel: DEFAULT_IMAGE_MODEL });
     saveImageModel(DEFAULT_IMAGE_MODEL);
   } else {
@@ -93,7 +97,12 @@ export function setImageModelImpl(imageModel: ImageModel, set: StoreSet, get: St
     }
     return;
   }
-  if (get().provider === "grok" || get().provider === "agy" || get().provider === "gemini-api") {
+  if (isAtlasCloudImageModel(imageModel)) {
+    saveGenerationDefaultsPatch({ provider: "atlascloud" });
+    set({ provider: "atlascloud", imageModel });
+    return;
+  }
+  if (get().provider === "grok" || get().provider === "agy" || get().provider === "gemini-api" || get().provider === "atlascloud") {
     saveGenerationDefaultsPatch({ provider: "oauth" });
     set({ provider: "oauth", imageModel });
     return;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,14 +1,15 @@
 export type UIMode = "classic" | "node" | "card-news" | "agent" | "assets" | "home";
 export type SettingsSection = "providers" | "workspace" | "general";
 export type HistoryStripLayout = "rail" | "horizontal" | "sidebar";
-export type Provider = "oauth" | "api" | "grok" | "grok-api" | "agy" | "gemini-api";
+export type Provider = "oauth" | "api" | "grok" | "grok-api" | "agy" | "gemini-api" | "atlascloud";
 export type Quality = "low" | "medium" | "high";
 export type Format = "png" | "jpeg" | "webp";
 export type Moderation = "low" | "auto";
 export type OpenAIImageModel = "gpt-5.5" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna";
 export type GrokImageModel = "grok-imagine-image" | "grok-imagine-image-quality";
 export type GeminiImageModel = "nano-banana-2" | "nano-banana-pro";
-export type ImageModel = OpenAIImageModel | GrokImageModel | GeminiImageModel;
+export type AtlasCloudImageModel = "openai/gpt-image-2/text-to-image" | "openai/gpt-image-2/edit";
+export type ImageModel = OpenAIImageModel | GrokImageModel | GeminiImageModel | AtlasCloudImageModel;
 export type VideoModel = "grok-imagine-video" | "grok-imagine-video-1.5" | "grok-imagine-video-1.5-preview";
 export type VideoResolutionUI = "480p" | "720p" | "1080p";
 export type UnsupportedImageModel = "gpt-5.3-codex-spark";


### PR DESCRIPTION
## Summary
- add an Atlas Cloud direct image provider using the Media API and ATLASCLOUD_API_KEY
- wire Atlas Cloud through provider option normalization, key management, generation/edit/multimode/node/agent paths, CLI flags, and UI model selection
- document the CLI provider semantics in docs/CLI.md without changing the root README

## Validation
- node --import tsx --test tests/atlascloud-provider-contract.test.ts tests/cli-feature-parity-contract.test.js tests/cli-capabilities-contract.test.js tests/provider-ui-polish-contract.test.js
- npm run typecheck
- npm run typecheck:tests
- npm run build:server
- npm run build:cli
- npm --prefix ui run build
- git diff --check
- Atlas Cloud live model catalog confirmed openai/gpt-image-2/text-to-image and openai/gpt-image-2/edit