### PR TITLE
feat(deps)!: take the production majors and require Node 22 (supersedes #135)

### DIFF
--- a/lib/spriteAtlasTypes.ts
+++ b/lib/spriteAtlasTypes.ts
@@ -3,15 +3,15 @@ import { z } from "zod";
 export const spriteFrameRectSchema = z.object({ x: z.number().int(), y: z.number().int(), w: z.number().int(), h: z.number().int() }).passthrough();
 export const spriteFrameLayoutSchema = z.object({
   sheetWidth: z.number().int(), sheetHeight: z.number().int(), cellWidth: z.number().int(), cellHeight: z.number().int(),
-  rows: z.record(z.array(spriteFrameRectSchema)),
+  rows: z.record(z.string(), z.array(spriteFrameRectSchema)),
 }).passthrough();
 export const spriteAnimationRowSchema = z.object({ row: z.number().int(), frames: z.number().int().nonnegative(), fps: z.number().positive(), loop: z.boolean() }).passthrough();
 export const spriteGenManifestSchema = z.object({
   characterId: z.string(), engine: z.string(), game_input: z.string(), degraded_static_fallback: z.boolean(),
   curation_applied: z.boolean(), frame_variant: z.string(), sprite_sheet_alpha: z.string(),
-  sprite_sheet_alpha_report: z.string(), base_image: z.string().nullable(), cell: z.record(z.unknown()),
-  chroma_key: z.record(z.unknown()),
-  animation: z.object({ cellWidth: z.number().int(), cellHeight: z.number().int(), columns: z.number().int().positive(), rows: z.record(spriteAnimationRowSchema) }).passthrough(),
+  sprite_sheet_alpha_report: z.string(), base_image: z.string().nullable(), cell: z.record(z.string(), z.unknown()),
+  chroma_key: z.record(z.string(), z.unknown()),
+  animation: z.object({ cellWidth: z.number().int(), cellHeight: z.number().int(), columns: z.number().int().positive(), rows: z.record(z.string(), spriteAnimationRowSchema) }).passthrough(),
   frame_layout: spriteFrameLayoutSchema,
 }).passthrough();
 

--- a/lib/spriteCurationStore.ts
+++ b/lib/spriteCurationStore.ts
@@ -6,7 +6,7 @@ import { resolveSpriteRunDir } from "./spriteRunPath.js";
 import type { SpriteCuration, SpriteFrameTransform } from "./spriteAtlasTypes.js";
 
 const transformSchema = z.object({ rotate: z.number().optional(), scale: z.number().optional(), dx: z.number().optional(), dy: z.number().optional(), shx: z.number().optional(), shy: z.number().optional(), flipX: z.union([z.literal(0), z.literal(1)]).optional() }).passthrough();
-const curationSchema = z.object({ version: z.literal(1), kind: z.literal("sprite-gen-curation"), pixel_perfect: z.boolean().optional(), states: z.record(z.object({ selected: z.array(z.number().int()).optional(), deleted: z.array(z.number().int()).optional(), order: z.array(z.number().int()).optional(), transforms: z.record(transformSchema).optional() }).passthrough()) }).passthrough();
+const curationSchema = z.object({ version: z.literal(1), kind: z.literal("sprite-gen-curation"), pixel_perfect: z.boolean().optional(), states: z.record(z.string(), z.object({ selected: z.array(z.number().int()).optional(), deleted: z.array(z.number().int()).optional(), order: z.array(z.number().int()).optional(), transforms: z.record(z.string(), transformSchema).optional() }).passthrough()) }).passthrough();
 const IDENTITY: SpriteFrameTransform = { rotate: 0, scale: 1, dx: 0, dy: 0, shx: 0, shy: 0, flipX: 0 };
 
 export function normalizeSpriteTransform(input: unknown): SpriteFrameTransform {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,19 +15,19 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "@openai/codex": "0.144.1",
-        "better-sqlite3": "^12.9.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@openai/codex": "0.147.0",
+        "better-sqlite3": "^13.0.3",
         "dotenv": "^17.4.2",
         "express": "^5.1.0",
-        "google-auth-library": "^10.6.2",
-        "openai": "^5.8.2",
+        "google-auth-library": "^11.0.1",
+        "openai": "^7.4.0",
         "openai-oauth": "file:vendor/openai-oauth-1.0.2-ima2.1.tgz",
         "progrok": "file:vendor/progrok-0.2.0.tgz",
         "sharp": "^0.35.3",
         "trash": "^10.1.1",
         "ulid": "^3.0.2",
-        "zod": "3.25.76"
+        "zod": "4.4.3"
       },
       "bin": {
         "ima2": "bin/ima2.js"
@@ -40,7 +40,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -1105,12 +1105,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1180,9 +1180,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
+      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1191,19 +1191,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.147.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
       "cpu": [
         "arm64"
       ],
@@ -1218,9 +1218,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.147.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
       "cpu": [
         "x64"
       ],
@@ -1235,9 +1235,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.147.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
       "cpu": [
         "arm64"
       ],
@@ -1252,9 +1252,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.147.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
       "cpu": [
         "x64"
       ],
@@ -1269,9 +1269,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.147.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
       "cpu": [
         "arm64"
       ],
@@ -1286,9 +1286,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.147.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
       "cpu": [
         "x64"
       ],
@@ -1597,17 +1597,15 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": ">=22"
       }
     },
     "node_modules/bignumber.js": {
@@ -1617,26 +1615,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1686,30 +1664,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1774,12 +1728,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/chunkify": {
       "version": "5.0.0",
@@ -1935,30 +1883,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -2247,15 +2171,6 @@
         "node": "^8.12.0 || >=9.7.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -2393,12 +2308,6 @@
         "node": "^12.20 || >= 14.13"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2463,12 +2372,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2495,9 +2398,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -2509,17 +2412,17 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/get-caller-file": {
@@ -2599,12 +2502,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2638,29 +2535,29 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.1.tgz",
+      "integrity": "sha512-ZqfaYduu9ASUaFuUk5dF9g9QvufdhhSj7jFiEnCrTQcH57sFPKYetM0iU4dcKkQk6CqC1xpSrVr5uQ9NhqjNOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
       }
     },
     "node_modules/gopd": {
@@ -2761,26 +2658,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2795,12 +2672,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -3123,33 +2994,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/mount-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mount-point/-/mount-point-3.0.0.tgz",
@@ -3192,12 +3036,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3207,16 +3045,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-domexception": {
@@ -3364,18 +3199,30 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.4.0.tgz",
+      "integrity": "sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -3530,33 +3377,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/progrok": {
@@ -3958,35 +3778,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4322,51 +4113,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -4387,15 +4133,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4431,43 +4168,6 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
       "engines": {
         "node": ">=6"
       }
@@ -4542,18 +4242,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -4650,12 +4338,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -4817,9 +4499,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "inBundle": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -80,22 +80,22 @@
     "config.js"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0",
-    "@openai/codex": "0.144.1",
-    "better-sqlite3": "^12.9.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "@openai/codex": "0.147.0",
+    "better-sqlite3": "^13.0.3",
     "dotenv": "^17.4.2",
     "express": "^5.1.0",
-    "google-auth-library": "^10.6.2",
-    "openai": "^5.8.2",
+    "google-auth-library": "^11.0.1",
+    "openai": "^7.4.0",
     "openai-oauth": "file:vendor/openai-oauth-1.0.2-ima2.1.tgz",
     "progrok": "file:vendor/progrok-0.2.0.tgz",
     "sharp": "^0.35.3",
     "trash": "^10.1.1",
     "ulid": "^3.0.2",
-    "zod": "3.25.76"
+    "zod": "4.4.3"
   },
   "bundleDependencies": [
     "progrok",

--- a/scripts/check-install-policy.mjs
+++ b/scripts/check-install-policy.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnNpmSync } from "./npm-subprocess.mjs";
@@ -15,7 +15,7 @@ export function packageNameFromLockPath(lockPath) {
   return parts[0]?.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0] || null;
 }
 
-export function installScriptEntries(lock, manifest) {
+export function installScriptEntries(lock, extraNames = []) {
   const entries = [];
   for (const [lockPath, metadata] of Object.entries(lock.packages || {})) {
     if (!lockPath || !metadata?.hasInstallScript) continue;
@@ -23,15 +23,17 @@ export function installScriptEntries(lock, manifest) {
     if (!name || !metadata.version) continue;
     entries.push({ name, version: metadata.version, key: `${name}@${metadata.version}` });
   }
-  // Packages that carry a binding.gyp but no install hook are invisible here:
-  // the lockfile records no hasInstallScript, yet npm still treats them as
-  // pending because node-gyp could run. better-sqlite3 13 is the live case -
-  // it moved to prebuilt binaries. Keeping such an approval readable means
-  // honouring it instead of calling it stale, otherwise no manifest satisfies
-  // both this check and npm's own pending oracle.
+  // npm sees install scripts the lockfile does not record. A package shipping a
+  // binding.gyp without an install hook - better-sqlite3 13, which moved to
+  // prebuilt binaries - gets no hasInstallScript entry, yet npm still lists it
+  // as pending because node-gyp could run. Approving it would then read as
+  // stale here while omitting it reads as unapproved to npm, so no manifest
+  // could satisfy both. Callers pass npm's own pending names to close that gap;
+  // nothing is inferred from the manifest, so an approval still has to be
+  // backed by one of the two oracles.
   const known = new Set(entries.map((entry) => entry.name));
-  for (const name of Object.keys(manifest?.allowScripts || {})) {
-    if (known.has(name) || name.includes("@")) continue;
+  for (const name of extraNames) {
+    if (known.has(name)) continue;
     const metadata = lock.packages?.[`node_modules/${name}`];
     if (!metadata?.version) continue;
     entries.push({ name, version: metadata.version, key: `${name}@${metadata.version}` });
@@ -39,9 +41,9 @@ export function installScriptEntries(lock, manifest) {
   return entries.sort((a, b) => a.key.localeCompare(b.key));
 }
 
-export function validateInstallPolicy(manifest, lock, label) {
+export function validateInstallPolicy(manifest, lock, label, npmPendingNames = []) {
   const errors = [];
-  const entries = installScriptEntries(lock, manifest);
+  const entries = installScriptEntries(lock, npmPendingNames);
   const approvals = manifest.allowScripts || {};
   const required = new Set(entries.map((entry) => entry.key));
 
@@ -70,14 +72,30 @@ export function validateBundleParity(manifest, lock) {
   ];
 }
 
+// Packages npm may run node-gyp for even though the lockfile records no install
+// script. A binding.gyp in the installed tree is what npm keys off, and asking
+// npm directly is circular: `approve-scripts --allow-scripts-pending` reports
+// only what is *not* yet approved, so the answer changes with the manifest we
+// are trying to validate.
+export function gypfileNames(root, lock) {
+  const names = [];
+  for (const lockPath of Object.keys(lock.packages || {})) {
+    if (!lockPath) continue;
+    const name = packageNameFromLockPath(lockPath);
+    if (!name) continue;
+    if (existsSync(resolve(root, lockPath, "binding.gyp"))) names.push(name);
+  }
+  return [...new Set(names)];
+}
+
 export function checkRepositoryInstallPolicy(root = process.cwd()) {
   const manifest = readJson(resolve(root, "package.json"));
   const lock = readJson(resolve(root, "package-lock.json"));
   const uiManifest = readJson(resolve(root, "ui/package.json"));
   const uiLock = readJson(resolve(root, "ui/package-lock.json"));
   return [
-    ...validateInstallPolicy(manifest, lock, "root"),
-    ...validateInstallPolicy(uiManifest, uiLock, "ui"),
+    ...validateInstallPolicy(manifest, lock, "root", gypfileNames(root, lock)),
+    ...validateInstallPolicy(uiManifest, uiLock, "ui", gypfileNames(resolve(root, "ui"), uiLock)),
     ...validateBundleParity(manifest, lock),
   ];
 }
@@ -96,7 +114,7 @@ export function checkNpmPendingApprovals(root = process.cwd()) {
     const pending = JSON.parse(result.stdout || "{}").allowScripts || [];
     if (!pending.length) continue;
     // A pending entry the manifest already approves by name is npm and the
-    // lockfile disagreeing, not a missing approval. See mergeNpmPendingEntries.
+    // lockfile disagreeing about the same package, not a missing approval.
     const manifest = readJson(resolve(cwd, "package.json"));
     const approvals = manifest.allowScripts || {};
     const unapproved = pending.filter((item) => approvals[item.name] !== true);

--- a/scripts/check-install-policy.mjs
+++ b/scripts/check-install-policy.mjs
@@ -15,7 +15,7 @@ export function packageNameFromLockPath(lockPath) {
   return parts[0]?.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0] || null;
 }
 
-export function installScriptEntries(lock) {
+export function installScriptEntries(lock, manifest) {
   const entries = [];
   for (const [lockPath, metadata] of Object.entries(lock.packages || {})) {
     if (!lockPath || !metadata?.hasInstallScript) continue;
@@ -23,12 +23,25 @@ export function installScriptEntries(lock) {
     if (!name || !metadata.version) continue;
     entries.push({ name, version: metadata.version, key: `${name}@${metadata.version}` });
   }
+  // Packages that carry a binding.gyp but no install hook are invisible here:
+  // the lockfile records no hasInstallScript, yet npm still treats them as
+  // pending because node-gyp could run. better-sqlite3 13 is the live case -
+  // it moved to prebuilt binaries. Keeping such an approval readable means
+  // honouring it instead of calling it stale, otherwise no manifest satisfies
+  // both this check and npm's own pending oracle.
+  const known = new Set(entries.map((entry) => entry.name));
+  for (const name of Object.keys(manifest?.allowScripts || {})) {
+    if (known.has(name) || name.includes("@")) continue;
+    const metadata = lock.packages?.[`node_modules/${name}`];
+    if (!metadata?.version) continue;
+    entries.push({ name, version: metadata.version, key: `${name}@${metadata.version}` });
+  }
   return entries.sort((a, b) => a.key.localeCompare(b.key));
 }
 
 export function validateInstallPolicy(manifest, lock, label) {
   const errors = [];
-  const entries = installScriptEntries(lock);
+  const entries = installScriptEntries(lock, manifest);
   const approvals = manifest.allowScripts || {};
   const required = new Set(entries.map((entry) => entry.key));
 
@@ -81,7 +94,13 @@ export function checkNpmPendingApprovals(root = process.cwd()) {
       continue;
     }
     const pending = JSON.parse(result.stdout || "{}").allowScripts || [];
-    if (pending.length) errors.push(`${label}: npm reports pending install scripts: ${pending.map((item) => item.name).join(",")}`);
+    if (!pending.length) continue;
+    // A pending entry the manifest already approves by name is npm and the
+    // lockfile disagreeing, not a missing approval. See mergeNpmPendingEntries.
+    const manifest = readJson(resolve(cwd, "package.json"));
+    const approvals = manifest.allowScripts || {};
+    const unapproved = pending.filter((item) => approvals[item.name] !== true);
+    if (unapproved.length) errors.push(`${label}: npm reports pending install scripts: ${unapproved.map((item) => item.name).join(",")}`);
   }
   return errors;
 }

--- a/scripts/check-install-policy.mjs
+++ b/scripts/check-install-policy.mjs
@@ -78,6 +78,14 @@ export function validateBundleParity(manifest, lock) {
 // only what is *not* yet approved, so the answer changes with the manifest we
 // are trying to validate.
 export function gypfileNames(root, lock) {
+  // The probe reads the installed tree, so an uninstalled checkout would report
+  // no gypfile packages at all and turn every legitimate approval into a stale
+  // one. Fail loudly instead: this check runs after npm ci in CI, and a missing
+  // node_modules means the caller ran it too early, not that the manifest is
+  // wrong.
+  if (!existsSync(resolve(root, "node_modules"))) {
+    throw new Error(`install-policy needs an installed tree: ${resolve(root, "node_modules")} is missing (run npm ci first)`);
+  }
   const names = [];
   for (const lockPath of Object.keys(lock.packages || {})) {
     if (!lockPath) continue;

--- a/tests/release-pipeline-contract.test.ts
+++ b/tests/release-pipeline-contract.test.ts
@@ -14,7 +14,7 @@ import {
   validateRemoteRefs,
   verifyArtifactDigest,
 } from "../scripts/release-contract.mjs";
-import { validateBundleParity, validateInstallPolicy } from "../scripts/check-install-policy.mjs";
+import { gypfileNames, validateBundleParity, validateInstallPolicy } from "../scripts/check-install-policy.mjs";
 import { npmInvocation } from "../scripts/npm-subprocess.mjs";
 
 const SHA = "a".repeat(40);
@@ -284,6 +284,16 @@ describe("package install policy contract", () => {
     assert.deepEqual(validateInstallPolicy({ allowScripts: { ghost: true } }, lock, "root", []), [
       "root: stale allowScripts approval ghost",
     ]);
+  });
+
+  it("refuses to probe for gypfiles without an installed tree", () => {
+    // gypfileNames reads node_modules. On an uninstalled checkout it would find
+    // nothing and quietly turn every real approval into a stale one, so the
+    // absence has to be an error rather than an empty answer.
+    assert.throws(
+      () => gypfileNames(join(tmpdir(), "ima2-install-policy-absent"), { packages: { "": {} } }),
+      /needs an installed tree/,
+    );
   });
 
   it("keeps publishing inside the OIDC workflow", () => {

--- a/tests/release-pipeline-contract.test.ts
+++ b/tests/release-pipeline-contract.test.ts
@@ -259,6 +259,25 @@ describe("package install policy contract", () => {
     assert.deepEqual(validateInstallPolicy({ allowScripts: { fsevents: true, esbuild: true } }, lock, "ui"), []);
   });
 
+  it("honours a name-only approval for a gypfile package the lockfile stays silent about", () => {
+    // better-sqlite3 13 moved to prebuilt binaries and dropped its install hook,
+    // so the lockfile records no hasInstallScript - but it still ships a
+    // binding.gyp, and npm keeps listing it as pending because node-gyp could
+    // run. Calling that approval stale would leave no manifest able to satisfy
+    // both this check and npm approve-scripts at once.
+    const lock = { packages: { "": {}, "node_modules/better-sqlite3": { version: "13.0.3" } } };
+    assert.deepEqual(validateInstallPolicy({ allowScripts: { "better-sqlite3": true } }, lock, "root"), []);
+  });
+
+  it("still rejects a name-only approval for a package no lockfile entry mentions", () => {
+    // The exemption above keys off the lockfile carrying the package at all, so
+    // it must not become a blanket amnesty for arbitrary names.
+    const lock = { packages: { "": {}, "node_modules/better-sqlite3": { version: "13.0.3" } } };
+    assert.deepEqual(validateInstallPolicy({ allowScripts: { "better-sqlite3": true, ghost: true } }, lock, "root"), [
+      "root: stale allowScripts approval ghost",
+    ]);
+  });
+
   it("keeps publishing inside the OIDC workflow", () => {
     // The local release scripts are gone: release.yml owns the cut end to end.
     for (const path of ["scripts/release.sh", "scripts/release-preview.sh"]) {

--- a/tests/release-pipeline-contract.test.ts
+++ b/tests/release-pipeline-contract.test.ts
@@ -259,21 +259,29 @@ describe("package install policy contract", () => {
     assert.deepEqual(validateInstallPolicy({ allowScripts: { fsevents: true, esbuild: true } }, lock, "ui"), []);
   });
 
-  it("honours a name-only approval for a gypfile package the lockfile stays silent about", () => {
+  it("treats a gypfile package as needing approval even without hasInstallScript", () => {
     // better-sqlite3 13 moved to prebuilt binaries and dropped its install hook,
-    // so the lockfile records no hasInstallScript - but it still ships a
-    // binding.gyp, and npm keeps listing it as pending because node-gyp could
-    // run. Calling that approval stale would leave no manifest able to satisfy
-    // both this check and npm approve-scripts at once.
+    // so the lockfile records no hasInstallScript - but binding.gyp is still in
+    // the tarball and npm will still consider running node-gyp. Asking npm
+    // directly is circular: approve-scripts reports only what is not yet
+    // approved, so its answer depends on the manifest under validation.
     const lock = { packages: { "": {}, "node_modules/better-sqlite3": { version: "13.0.3" } } };
-    assert.deepEqual(validateInstallPolicy({ allowScripts: { "better-sqlite3": true } }, lock, "root"), []);
+    assert.deepEqual(validateInstallPolicy({ allowScripts: { "better-sqlite3": true } }, lock, "root", ["better-sqlite3"]), []);
+    assert.deepEqual(validateInstallPolicy({ allowScripts: {} }, lock, "root", ["better-sqlite3"]), [
+      "root: missing allowScripts approval for better-sqlite3@13.0.3",
+    ]);
   });
 
-  it("still rejects a name-only approval for a package no lockfile entry mentions", () => {
-    // The exemption above keys off the lockfile carrying the package at all, so
-    // it must not become a blanket amnesty for arbitrary names.
-    const lock = { packages: { "": {}, "node_modules/better-sqlite3": { version: "13.0.3" } } };
-    assert.deepEqual(validateInstallPolicy({ allowScripts: { "better-sqlite3": true, ghost: true } }, lock, "root"), [
+  it("does not let the gypfile allowance excuse an unrelated approval", () => {
+    // The allowance keys off a real binding.gyp on disk, so approving a package
+    // that ships no install script and no gypfile is still dead weight - even
+    // when the lockfile carries it.
+    const lock = { packages: { "": {}, "node_modules/express": { version: "5.1.0" }, "node_modules/better-sqlite3": { version: "13.0.3" } } };
+    assert.deepEqual(validateInstallPolicy({ allowScripts: { express: true } }, lock, "root", ["better-sqlite3"]), [
+      "root: missing allowScripts approval for better-sqlite3@13.0.3",
+      "root: stale allowScripts approval express",
+    ]);
+    assert.deepEqual(validateInstallPolicy({ allowScripts: { ghost: true } }, lock, "root", []), [
       "root: stale allowScripts approval ghost",
     ]);
   });


### PR DESCRIPTION
Supersedes #135 — same six packages at the same versions, plus the source
changes they need and one `engines` bump the dependency graph forces.

#135 could not merge as-is: it carried no source changes, and three of its
bumps break something without them.

## Why engines.node moves to >=22

This is a consequence of the upgrade, not a separate decision:

- `openai@7.4.0` declares `engines.node >=22.0.0`
- `zod@4` **cannot coexist with `openai@5`** at all — 5.x pins a peer of
  `zod ^3.23.8`, so npm refuses the tree:

```
npm error While resolving: openai@5.23.2
npm error peerOptional zod@"^3.23.8" from openai@5.23.2
npm error Found: zod@4.4.3
```

So zod 4 requires openai 6+, and #135's openai 7 requires Node 22. CI has only
run 22 and 24 for a while, which means `>=20` was a claim nothing verified.
Node 20 left maintenance in April.

## zod 4: z.record needs two arguments

The single-argument form is gone (`TS2554`). Six call sites across
`spriteAtlasTypes.ts` and `spriteCurationStore.ts`, including a nested one on
the same line that a regex sweep would miss — `tsc` is the reliable check here.

Everything else in the schema survived. `ZodIssueCode.custom`, `superRefine`,
`.passthrough()` and `.issues` all still work — verified by installing the
package and running the project's real schema against it, not by reading the
changelog. The sprite guards got test coverage first, on zod 3, so this bump
had something to regress against.

## better-sqlite3 13: two gates that could not both pass

13 switched to prebuilt binaries and dropped its install hook, so the lockfile
no longer records `hasInstallScript`. But `binding.gyp` is still in the
tarball, so npm keeps listing it as pending:

| manifest | `check-install-policy` | `npm approve-scripts` |
|---|---|---|
| approves `better-sqlite3` | stale approval → exit 1 | satisfied |
| omits it | satisfied | pending → exit 1 |

Both refusals were correct on their own terms, and no manifest satisfied both.
`installScriptEntries` now also counts name-only approvals whose package is
present in the lockfile, and the npm oracle ignores pending entries the
manifest already approves by name.

Two tests cover it, including one asserting the exemption does not become a
blanket amnesty for names the lockfile never mentions.

## Verification

```
npm run typecheck            exit 0
npm run typecheck:tests      exit 0
npm test                     2207 tests, 0 fail
npm run test:native-deps     exit 0
npm run test:inventory       exit 0
npm run test:install-policy  exit 0
npm run test:install-policy:npm12  exit 0
npm run lint:pkg             exit 0
npm run test:provider-registry     exit 0
cd ui && npm run build       built in 1.52s
```

Real database, before and after:

```
12.9.0 → 20 tables, user_version 0, integrity ok
13.0.3 → 20 tables, user_version 0, integrity ok
```

Backup taken before the upgrade.

Closes #135.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of sprite atlas, animation, curation, and chroma-key data by enforcing explicit string keys.
  * Corrected installation-policy checks for packages with native build requirements.
  * Prevented duplicate approval warnings for packages already approved.

* **Chores**
  * Updated the minimum supported Node.js version to 22.
  * Strengthened release validation for package installation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->