### PR TITLE
fix(agent): make tools inspector a non-modal side panel

### DIFF
--- a/tests/agent-mode-right-sidebar-contract.test.js
+++ b/tests/agent-mode-right-sidebar-contract.test.js
@@ -36,7 +36,6 @@ describe("Agent Mode right sidebar contract", () => {
     assert.doesNotMatch(chat, /agent-model-chip/);
     assert.doesNotMatch(chat, /formatModelSummary/);
     assert.match(sidebar, /AgentImagePane/);
-    assert.match(sidebar, /agent-dialog--tools/);
     assert.match(sidebar, /useAgentDialogFocus/);
     assert.match(sidebar, /SidebarBody/);
     assert.match(sidebar, /AgentPromptLibraryPanel/);
@@ -63,6 +62,43 @@ describe("Agent Mode right sidebar contract", () => {
     assert.match(css, /\.agent-sidebar-tabs/);
     assert.match(en, /"quickSettingsMenu": "Model and reasoning quick settings"/);
     assert.match(ko, /"quickSettingsMenu": "모델 및 추론 빠른 설정"/);
+  });
+
+  it("renders the tools inspector as a non-modal side panel", () => {
+    const sidebar = readSource("ui/src/components/agent/AgentRightSidebar.tsx");
+    const focus = readSource("ui/src/components/agent/useAgentDialogFocus.ts");
+    const stage = readSource("ui/src/components/agent/AgentStagePane.tsx");
+    const workspace = readSource("ui/src/components/agent/AgentWorkspace.tsx");
+    const tabs = readSource("ui/src/components/agent/AgentSidebarTabs.tsx");
+    const css = readSource("ui/src/styles/agent-stage.css");
+
+    // A non-blocking inspector must not claim modal semantics, must not put a
+    // full-viewport scrim over the workspace, and must not swallow an outside
+    // click as cancellation.
+    assert.doesNotMatch(sidebar, /aria-modal=/);
+    assert.doesNotMatch(sidebar, /agent-dialog__backdrop/);
+    assert.doesNotMatch(sidebar, /agent-dialog--tools/);
+    assert.match(sidebar, /aria-labelledby="agent-tools-panel-title"/);
+    assert.match(sidebar, /<h2 id="agent-tools-panel-title"/);
+    assert.match(sidebar, /\{ modal: false \}/);
+
+    // Focus trap stays opt-in for genuinely modal drawers only.
+    assert.match(focus, /options: Options = \{\}/);
+    assert.match(focus, /if \(!modal \|\| event\.key !== "Tab"\) return;/);
+    assert.match(focus, /data-autofocus/);
+
+    // The trigger is a disclosure control, so it reports its own state.
+    assert.match(stage, /aria-expanded=\{toolsPanelOpen === true\}/);
+    assert.match(workspace, /toggleToolsPanel/);
+    assert.match(workspace, /toolsPanelOpen=\{toolsPanelOpen\}/);
+
+    // APG tabs: one tab stop, arrow keys move selection.
+    assert.match(tabs, /tabIndex=\{activeTab === tab \? 0 : -1\}/);
+    assert.match(tabs, /ArrowRight/);
+    assert.match(tabs, /onKeyDown=\{handleKeyDown\}/);
+
+    assert.match(css, /\.agent-right-sidebar--overlay/);
+    assert.doesNotMatch(css, /\.agent-dialog--tools/);
   });
 
   it("syncs sidebar settings and queue actions through the server-backed workspace", () => {

--- a/tests/agent-mode-right-sidebar-contract.test.js
+++ b/tests/agent-mode-right-sidebar-contract.test.js
@@ -99,6 +99,37 @@ describe("Agent Mode right sidebar contract", () => {
 
     assert.match(css, /\.agent-right-sidebar--overlay/);
     assert.doesNotMatch(css, /\.agent-dialog--tools/);
+
+    // The disclosure must control the panel, not its heading.
+    assert.match(sidebar, /id="agent-tools-panel"/);
+    assert.match(stage, /aria-controls="agent-tools-panel"/);
+    assert.doesNotMatch(stage, /aria-controls="agent-tools-panel-title"/);
+  });
+
+  it("docks the tools panel into its own column instead of covering the stage", () => {
+    const workspace = readSource("ui/src/components/agent/AgentWorkspace.tsx");
+    const stageCss = readSource("ui/src/styles/agent-stage.css");
+
+    // A non-modal panel leaves the background focusable, so overlaying the stage
+    // would let Shift+Tab reach a control hidden underneath (WCAG 2.4.11).
+    assert.match(workspace, /agent-workspace--tools-docked/);
+    assert.match(stageCss, /\.agent-workspace--tools-docked \.agent-workspace__body/);
+    assert.match(stageCss, /\.agent-workspace--tools-docked \.agent-right-sidebar--overlay/);
+
+    // The panel must render inside the body grid for the docked column to apply.
+    const bodyStart = workspace.indexOf('<div className="agent-workspace__body">');
+    const bodyEnd = workspace.indexOf("<AgentSessionDrawer");
+    const overlayIndex = workspace.indexOf("{isDesktop && toolsPanelOpen ? (");
+    assert.ok(bodyStart > 0, "the workspace body element must exist");
+    assert.ok(
+      overlayIndex > bodyStart && overlayIndex < bodyEnd,
+      "the overlay panel must render inside the workspace body grid",
+    );
+
+    // The filmstrip must stay inside its grid track or trailing thumbs remain
+    // focusable while clipped out of view under the docked panel.
+    const filmBlock = stageCss.slice(stageCss.indexOf(".agent-stage__filmstrip {"));
+    assert.match(filmBlock.slice(0, filmBlock.indexOf("}")), /min-width: 0/);
   });
 
   it("syncs sidebar settings and queue actions through the server-backed workspace", () => {

--- a/ui/src/components/agent/AgentRightSidebar.tsx
+++ b/ui/src/components/agent/AgentRightSidebar.tsx
@@ -112,6 +112,7 @@ export function AgentRightSidebar({ overlay, onClose, ...rest }: Props) {
     return (
       <section
         ref={panelRef}
+        id="agent-tools-panel"
         className="agent-right-sidebar agent-right-sidebar--overlay"
         role="dialog"
         aria-labelledby="agent-tools-panel-title"

--- a/ui/src/components/agent/AgentRightSidebar.tsx
+++ b/ui/src/components/agent/AgentRightSidebar.tsx
@@ -103,19 +103,25 @@ const noop = () => {};
 
 export function AgentRightSidebar({ overlay, onClose, ...rest }: Props) {
   const { t } = useI18n();
-  const panelRef = useAgentDialogFocus(overlay === true, onClose ?? noop);
+  // The tools inspector is a non-modal side panel: the chat and stage behind it
+  // stay usable, so it must not trap focus, must not claim aria-modal, and must
+  // not treat an outside click as cancellation (APG dialog pattern + Fluent 2
+  // non-modal guidance). Escape closes it and focus returns to the trigger.
+  const panelRef = useAgentDialogFocus(overlay === true, onClose ?? noop, { modal: false });
   if (overlay) {
     return (
-      <div className="agent-dialog agent-dialog--tools" role="presentation">
-        <button type="button" className="agent-dialog__backdrop" onClick={onClose} aria-label={t("agent.closeTools")} />
-        <section ref={panelRef} className="agent-right-sidebar agent-right-sidebar--overlay" role="dialog" aria-modal="true" aria-label={t("agent.openTools")}>
-          <header className="agent-right-sidebar__overlay-header">
-            <strong>{t("agent.openTools")}</strong>
-            <button type="button" onClick={onClose} aria-label={t("agent.closeTools")}><CloseIcon size={17} /></button>
-          </header>
-          <SidebarBody {...rest} />
-        </section>
-      </div>
+      <section
+        ref={panelRef}
+        className="agent-right-sidebar agent-right-sidebar--overlay"
+        role="dialog"
+        aria-labelledby="agent-tools-panel-title"
+      >
+        <header className="agent-right-sidebar__overlay-header">
+          <h2 id="agent-tools-panel-title" tabIndex={-1} data-autofocus>{t("agent.toolsPanel")}</h2>
+          <button type="button" onClick={onClose} aria-label={t("agent.closeTools")}><CloseIcon size={17} /></button>
+        </header>
+        <SidebarBody {...rest} />
+      </section>
     );
   }
   return (

--- a/ui/src/components/agent/AgentSidebarTabs.tsx
+++ b/ui/src/components/agent/AgentSidebarTabs.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useRef, type KeyboardEvent } from "react";
 import { useI18n } from "../../i18n";
 import type { AgentSidebarTab } from "./agentTypes";
 
@@ -10,6 +11,24 @@ const TABS: AgentSidebarTab[] = ["image", "library", "forms", "quality", "model"
 
 export function AgentSidebarTabs({ activeTab, onChange }: Props) {
   const { t } = useI18n();
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  // APG tabs pattern: the tab list is one tab stop and arrow keys move between
+  // tabs. Without this, reaching Queue took six Tab presses inside the panel.
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLButtonElement>) => {
+    const current = TABS.indexOf(activeTab);
+    const base = current >= 0 ? current : 0;
+    let next: number | null = null;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") next = (base + 1) % TABS.length;
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") next = (base - 1 + TABS.length) % TABS.length;
+    if (event.key === "Home") next = 0;
+    if (event.key === "End") next = TABS.length - 1;
+    if (next === null) return;
+    event.preventDefault();
+    const tab = TABS[next];
+    onChange(tab);
+    tabRefs.current[tab]?.focus();
+  }, [activeTab, onChange]);
 
   return (
     <div className="agent-sidebar-tabs" role="tablist" aria-label={t("agent.rightSidebar")}>
@@ -19,9 +38,12 @@ export function AgentSidebarTabs({ activeTab, onChange }: Props) {
           type="button"
           role="tab"
           id={`agent-sidebar-tab-${tab}`}
+          ref={(node) => { tabRefs.current[tab] = node; }}
           aria-controls={`agent-sidebar-panel-${tab}`}
           className={activeTab === tab ? "active" : ""}
           aria-selected={activeTab === tab}
+          tabIndex={activeTab === tab ? 0 : -1}
+          onKeyDown={handleKeyDown}
           onClick={() => onChange(tab)}
         >
           {t(`agent.sidebarTabs.${tab}`)}

--- a/ui/src/components/agent/AgentStagePane.tsx
+++ b/ui/src/components/agent/AgentStagePane.tsx
@@ -14,7 +14,7 @@ type Props = {
   onOpenPanel: () => void;
 };
 
-export function AgentStagePane({ currentImage, images, onImageSelect, onOpenPanel }: Props) {
+export function AgentStagePane({ currentImage, images, onImageSelect, onOpenPanel, toolsPanelOpen }: Props & { toolsPanelOpen?: boolean }) {
   const { t } = useI18n();
   const thumbRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const currentIndex = useMemo(
@@ -52,7 +52,15 @@ export function AgentStagePane({ currentImage, images, onImageSelect, onOpenPane
           <span>{t("agent.imagePane")}</span>
           <strong>{t("agent.currentImage")}</strong>
         </div>
-        <button type="button" className="agent-stage__tools" onClick={onOpenPanel} aria-label={t("agent.openTools")} title={t("agent.openTools")}>
+        <button
+          type="button"
+          className="agent-stage__tools"
+          onClick={onOpenPanel}
+          aria-expanded={toolsPanelOpen === true}
+          aria-controls="agent-tools-panel-title"
+          aria-label={toolsPanelOpen ? t("agent.closeTools") : t("agent.openTools")}
+          title={toolsPanelOpen ? t("agent.closeTools") : t("agent.openTools")}
+        >
           <SlidersIcon size={16} />
         </button>
       </header>

--- a/ui/src/components/agent/AgentStagePane.tsx
+++ b/ui/src/components/agent/AgentStagePane.tsx
@@ -57,7 +57,7 @@ export function AgentStagePane({ currentImage, images, onImageSelect, onOpenPane
           className="agent-stage__tools"
           onClick={onOpenPanel}
           aria-expanded={toolsPanelOpen === true}
-          aria-controls="agent-tools-panel-title"
+          aria-controls="agent-tools-panel"
           aria-label={toolsPanelOpen ? t("agent.closeTools") : t("agent.openTools")}
           title={toolsPanelOpen ? t("agent.closeTools") : t("agent.openTools")}
         >

--- a/ui/src/components/agent/AgentWorkspace.tsx
+++ b/ui/src/components/agent/AgentWorkspace.tsx
@@ -413,7 +413,11 @@ export function AgentWorkspace() {
   }
 
   return (
-    <main className={`agent-workspace agent-workspace--${layoutMode}`} data-layout={layoutMode} aria-label={t("agent.workspace")}>
+    <main
+      className={`agent-workspace agent-workspace--${layoutMode}${isDesktop && toolsPanelOpen ? " agent-workspace--tools-docked" : ""}`}
+      data-layout={layoutMode}
+      aria-label={t("agent.workspace")}
+    >
       {useSessionRail ? (
         <div className="agent-session-rail-wrap">
           <AgentSessionRail sessions={workspace.sessions} selectedId={selectedSessionId ?? ""} imagesById={workspace.imagesById} runSummaryBySession={workspace.runSummaryBySession} onCreate={createSession} onSelect={selectSession} onOpenDrawer={() => setDrawerOpen(true)} />
@@ -468,27 +472,29 @@ export function AgentWorkspace() {
             onRetryQueue={retryQueue}
           />
         ) : null}
+        {/* Rendered inside the body so the docked layout can give it a column
+            instead of covering the stage. */}
+        {isDesktop && toolsPanelOpen ? (
+          <AgentRightSidebar
+            overlay
+            onClose={closeToolsPanel}
+            currentImage={currentImage}
+            images={images}
+            contextTab={activeTab}
+            sidebarTab={sidebarTab}
+            queueItems={queueItems}
+            runSummary={selectedRunSummary}
+            settings={selectedSettings}
+            onContextTabChange={setActiveTab}
+            onSidebarTabChange={setSidebarTab}
+            onImageSelect={selectImage}
+            onSettingsChange={updateGenerationSettings}
+            onInsertPrompt={insertPrompt}
+            onCancelQueue={cancelQueue}
+            onRetryQueue={retryQueue}
+          />
+        ) : null}
       </div>
-      {isDesktop && toolsPanelOpen ? (
-        <AgentRightSidebar
-          overlay
-          onClose={closeToolsPanel}
-          currentImage={currentImage}
-          images={images}
-          contextTab={activeTab}
-          sidebarTab={sidebarTab}
-          queueItems={queueItems}
-          runSummary={selectedRunSummary}
-          settings={selectedSettings}
-          onContextTabChange={setActiveTab}
-          onSidebarTabChange={setSidebarTab}
-          onImageSelect={selectImage}
-          onSettingsChange={updateGenerationSettings}
-          onInsertPrompt={insertPrompt}
-          onCancelQueue={cancelQueue}
-          onRetryQueue={retryQueue}
-        />
-      ) : null}
       <AgentSessionDrawer open={drawerOpen} sessions={workspace.sessions} selectedId={selectedSessionId ?? ""} imagesById={workspace.imagesById} runSummaryBySession={workspace.runSummaryBySession} onClose={() => setDrawerOpen(false)} onCreate={createSession} onSelect={selectSession} onRename={renameSession} onDelete={deleteSession} />
       <AgentImageSheet open={imageSheetOpen} currentImage={currentImage} images={images} activeTab={activeTab} onTabChange={setActiveTab} onImageSelect={selectImage} onClose={() => setImageSheetOpen(false)} />
       <AgentQueueSheet open={queueSheetOpen} items={queueItems} summary={selectedRunSummary} onCancel={cancelQueue} onRetry={retryQueue} onClose={() => setQueueSheetOpen(false)} />

--- a/ui/src/components/agent/AgentWorkspace.tsx
+++ b/ui/src/components/agent/AgentWorkspace.tsx
@@ -148,6 +148,7 @@ export function AgentWorkspace() {
 
   const errorMessage = useCallback((error: unknown) => error instanceof Error ? error.message : String(error), []);
   const closeToolsPanel = useCallback(() => setToolsPanelOpen(false), []);
+  const toggleToolsPanel = useCallback(() => setToolsPanelOpen((open) => !open), []);
   const reportMutationError = useCallback((error: unknown) => {
     showToast(t("agent.workspaceActionFailed", { reason: errorMessage(error) }), true);
   }, [errorMessage, showToast, t]);
@@ -448,7 +449,7 @@ export function AgentWorkspace() {
           onRetryRun={retryFailedRun}
         />
         {isDesktop ? (
-          <AgentStagePane currentImage={currentImage} images={images} onImageSelect={selectImage} onOpenPanel={() => setToolsPanelOpen(true)} />
+          <AgentStagePane currentImage={currentImage} images={images} onImageSelect={selectImage} onOpenPanel={toggleToolsPanel} toolsPanelOpen={toolsPanelOpen} />
         ) : showRightSidebar ? (
           <AgentRightSidebar
             currentImage={currentImage}

--- a/ui/src/components/agent/useAgentDialogFocus.ts
+++ b/ui/src/components/agent/useAgentDialogFocus.ts
@@ -3,7 +3,15 @@ import { useEffect, useRef } from "react";
 const FOCUSABLE =
   'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
 
-export function useAgentDialogFocus(open: boolean, onClose: () => void) {
+type Options = {
+  // Non-modal panels leave the rest of the workspace usable, so they must not
+  // cycle Tab back into themselves (WAI-ARIA APG: only modal dialogs trap
+  // focus). Escape still closes, and focus still returns to the trigger.
+  modal?: boolean;
+};
+
+export function useAgentDialogFocus(open: boolean, onClose: () => void, options: Options = {}) {
+  const modal = options.modal !== false;
   const panelRef = useRef<HTMLDivElement>(null);
   const restoreRef = useRef<HTMLElement | null>(null);
 
@@ -11,7 +19,10 @@ export function useAgentDialogFocus(open: boolean, onClose: () => void) {
     if (!open) return;
     restoreRef.current = document.activeElement as HTMLElement | null;
     const focusTimer = window.setTimeout(() => {
-      panelRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+      const panel = panelRef.current;
+      if (!panel) return;
+      const heading = panel.querySelector<HTMLElement>("[data-autofocus]");
+      (heading ?? panel.querySelector<HTMLElement>(FOCUSABLE))?.focus();
     }, 0);
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -19,7 +30,7 @@ export function useAgentDialogFocus(open: boolean, onClose: () => void) {
         onClose();
         return;
       }
-      if (event.key !== "Tab") return;
+      if (!modal || event.key !== "Tab") return;
       const nodes = Array.from(panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
       if (nodes.length === 0) return;
       const first = nodes[0];
@@ -38,7 +49,7 @@ export function useAgentDialogFocus(open: boolean, onClose: () => void) {
       document.removeEventListener("keydown", onKeyDown);
       restoreRef.current?.focus();
     };
-  }, [onClose, open]);
+  }, [modal, onClose, open]);
 
   return panelRef;
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1065,6 +1065,7 @@
     "filename": "File",
     "prompt": "Prompt",
     "stageEmptyHint": "Send your first request to see the image here",
+    "toolsPanel": "Tools",
     "openTools": "Open tools panel",
     "closeTools": "Close tools panel"
   },

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -1065,6 +1065,7 @@
     "filename": "파일",
     "prompt": "프롬프트",
     "stageEmptyHint": "첫 요청을 보내면 여기에서 이미지를 확인할 수 있습니다",
+    "toolsPanel": "도구",
     "openTools": "도구 패널 열기",
     "closeTools": "도구 패널 닫기"
   },

--- a/ui/src/i18n/zh-Hans.json
+++ b/ui/src/i18n/zh-Hans.json
@@ -1065,6 +1065,7 @@
     "filename": "文件",
     "prompt": "提示词",
     "stageEmptyHint": "在此处发送您的第一个查看图片的请求",
+    "toolsPanel": "工具",
     "openTools": "打开工具面板",
     "closeTools": "关闭工具面板"
   },

--- a/ui/src/i18n/zh-Hant.json
+++ b/ui/src/i18n/zh-Hant.json
@@ -1065,6 +1065,7 @@
     "filename": "文件",
     "prompt": "提示詞",
     "stageEmptyHint": "在此處發送您的第一個查看圖片的請求",
+    "toolsPanel": "工具",
     "openTools": "打開工具面板",
     "closeTools": "關閉工具面板"
   },

--- a/ui/src/styles/agent-stage.css
+++ b/ui/src/styles/agent-stage.css
@@ -59,6 +59,9 @@
 }
 
 .agent-stage__filmstrip {
+  /* Without min-width the flex row grows past its grid track, so trailing
+     thumbs stay focusable while being clipped by .agent-stage's overflow. */
+  min-width: 0;
   display: flex;
   gap: 8px;
   overflow-x: auto;
@@ -102,7 +105,7 @@
 }
 
 /* Non-modal inspector: no page scrim, so the chat and stage behind it stay
-   readable and clickable. Depth comes from the panel's own shadow. */
+   readable and clickable. */
 .agent-right-sidebar--overlay {
   position: fixed;
   inset: 0 0 0 auto;
@@ -117,6 +120,27 @@
   border-left: 1px solid var(--border-strong, var(--border));
   box-shadow: -18px 0 48px var(--shadow-strong, rgba(0, 0, 0, 0.4));
   overflow: hidden;
+}
+
+/* Where there is room, the panel takes its own column instead of covering the
+   stage. A non-modal panel leaves the background focusable, so overlaying it
+   would let Shift+Tab land on a control hidden underneath (WCAG 2.4.11). */
+@media (min-width: 1180px) {
+  .agent-workspace--tools-docked .agent-workspace__body {
+    grid-template-columns:
+      minmax(320px, 0.34fr)
+      minmax(360px, 0.46fr)
+      min(420px, 32vw);
+  }
+
+  .agent-workspace--tools-docked .agent-right-sidebar--overlay {
+    position: relative;
+    inset: auto;
+    width: auto;
+    height: 100%;
+    z-index: 1;
+    box-shadow: none;
+  }
 }
 
 .agent-right-sidebar__overlay-header {

--- a/ui/src/styles/agent-stage.css
+++ b/ui/src/styles/agent-stage.css
@@ -101,19 +101,22 @@
   outline-offset: 1px;
 }
 
-.agent-dialog--tools .agent-right-sidebar--overlay {
-  position: absolute;
-  inset: 0 0 0 auto;
-  width: min(420px, 90vw);
-  height: 100%;
-  z-index: 30;
-  background: var(--surface);
-  border-left: 1px solid var(--border);
-  overflow-y: auto;
-}
-
+/* Non-modal inspector: no page scrim, so the chat and stage behind it stay
+   readable and clickable. Depth comes from the panel's own shadow. */
 .agent-right-sidebar--overlay {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(420px, 92vw);
+  height: 100dvh;
+  z-index: 60;
+  display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  background: var(--surface);
+  border-left: 1px solid var(--border-strong, var(--border));
+  box-shadow: -18px 0 48px var(--shadow-strong, rgba(0, 0, 0, 0.4));
+  overflow: hidden;
 }
 
 .agent-right-sidebar__overlay-header {
@@ -125,10 +128,16 @@
   border-bottom: 1px solid var(--border);
 }
 
-.agent-right-sidebar__overlay-header strong {
-  font-size: 12px;
-  color: var(--text-dim);
+.agent-right-sidebar__overlay-header h2 {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text);
   font-weight: 600;
+}
+
+.agent-right-sidebar__overlay-header h2:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .agent-right-sidebar__overlay-header button {


### PR DESCRIPTION
## Problem

The right-side tools popup wrapped a non-blocking inspector in modal dialog semantics. Measured in Chrome at 1440x813:

- `role="dialog"` + `aria-modal="true"` on a 420px side panel
- a full-viewport 1440x813 scrim, rendered as a bare `<button>`
- a Tab focus trap

So adjusting Quality or Model blocked the chat those settings were being tuned for, and an outside click read as cancellation while the background stayed live. The panel was also titled with an action string ("Open tools panel"), and the trigger never reported `aria-expanded`.

## Approach

WAI-ARIA APG separates modal from non-modal dialogs, and both [APG](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) and [Fluent 2](https://fluent2.microsoft.design/components/web/react/core/dialog/usage) are explicit that a non-blocking helper panel must not claim modal semantics, must not trap focus, and must not treat an outside click as cancellation. Escape-to-close and focus restore stay.

- Drop `aria-modal`, the scrim, and outside-click dismissal.
- Make the focus trap opt-in so the genuinely modal drawers (sessions, image sheet, queue sheet) keep it unchanged.
- Label the panel with a real `h2` and move initial focus there.
- Turn the stage trigger into a disclosure control that toggles and reports state.
- Give the tab list APG roving tabindex and arrow-key navigation; reaching Queue previously took six Tab presses.

## Verification

Chrome via CDP at 1440x813, against the running dev server:

| check | result |
|---|---|
| `aria-modal` on panel | absent |
| scrim node | none |
| trigger `aria-expanded` | `false` -> `true`, label swaps |
| initial focus | lands on the `h2` |
| Escape | closes, focus returns to trigger |
| composer behind panel | hit-testable (genuinely non-modal) |
| tab roving tabindex | selected 0, rest -1 |

Tab labels were measured in all four locales at the 420px width: longest is 51.9px against 62px available, so no clipping and no restructuring needed.

Agent contract tests: 9 pass. `tsc --noEmit` clean for `ui` and tests.

## Stack

1. **this PR** — panel semantics
2. tool-call rendering (`codex/agent-toolcall-rendering`)
3. streaming a11y and reduced motion (`codex/agent-streaming-a11y`)