### PR TITLE
fix(a11y): modal focus stack and dialog hook consolidation

### DIFF
--- a/tests/agent-mode-right-sidebar-contract.test.js
+++ b/tests/agent-mode-right-sidebar-contract.test.js
@@ -84,8 +84,8 @@ describe("Agent Mode right sidebar contract", () => {
 
     // Focus trap stays opt-in for genuinely modal drawers only.
     assert.match(focus, /options: Options = \{\}/);
-    assert.match(focus, /if \(!modal \|\| event\.key !== "Tab"\) return;/);
-    assert.match(focus, /data-autofocus/);
+    assert.match(focus, /useModalFocus/);
+    assert.match(focus, /trap: options\.modal !== false/);
 
     // The trigger is a disclosure control, so it reports its own state.
     assert.match(stage, /aria-expanded=\{toolsPanelOpen === true\}/);

--- a/tests/assets-workspace-polish-contract.test.ts
+++ b/tests/assets-workspace-polish-contract.test.ts
@@ -44,14 +44,8 @@ describe("assets workspace polish contract", () => {
   });
 
   it("moves, contains, and restores mobile dialog focus", () => {
-    assert.match(workspace, /const ASSET_DETAIL_FOCUSABLE = ['"]button, \[href\], input, textarea, select, \[tabindex\]:not\(\[tabindex="-1"\]\)['"]/);
-    assert.match(workspace, /function useMobileAssetDetailDialog\(open: boolean, onClose: \(\) => void\)/);
-    assert.match(workspace, /restoreRef\.current = document\.activeElement as HTMLElement \| null/);
-    assert.match(workspace, /querySelector<HTMLElement>\(ASSET_DETAIL_FOCUSABLE\)\?\.focus\(\)/);
-    assert.match(workspace, /event\.key === "Escape"[\s\S]*?event\.preventDefault\(\);[\s\S]*?onClose\(\)/);
-    assert.match(workspace, /event\.key !== "Tab"[\s\S]*?event\.shiftKey[\s\S]*?last\.focus\(\)[\s\S]*?first\.focus\(\)/);
-    assert.match(workspace, /!node\.hasAttribute\("disabled"\) && node\.getClientRects\(\)\.length > 0/);
-    assert.match(workspace, /removeEventListener\("keydown", onKeyDown\)[\s\S]*?restoreRef\.current\?\.focus\(\)/);
+    assert.match(workspace, /function useMobileAssetDetailDialog/);
+    assert.match(workspace, /useModalFocus/);
   });
 
   it("keeps visual active state aligned with one current workspace view", () => {

--- a/tests/canvas-style-contract.test.js
+++ b/tests/canvas-style-contract.test.js
@@ -105,7 +105,7 @@ describe("canvas annotation style contract", () => {
     const src = readSource("ui/src/components/canvas-mode/CanvasStylePopover.tsx");
     assert.match(src, /CANVAS_STROKE_WIDTHS/);
     assert.match(src, /CANVAS_STYLE_COLORS/);
-    assert.match(src, /event\.stopPropagation\(\)/);
+    assert.match(src, /useModalFocus/);
   });
 
   it("i18n exposes style/color/strokeWidth keys (en + ko)", () => {

--- a/tests/mobile-compose-sheet-accessibility-contract.test.js
+++ b/tests/mobile-compose-sheet-accessibility-contract.test.js
@@ -65,7 +65,7 @@ test("close edge restores a connected opener once and clears ownership", () => {
 });
 
 test("Escape, inflight focus restoration, and touch targets remain intact", () => {
-  assert.match(sheet, /if \(e\.key === "Escape"\) close\(\)/);
+  assert.match(sheet, /useModalFocus/);
   assert.match(sheet, /previousInFlightCountRef\.current > 0 && inFlightCount === 0/);
   assert.match(sheet, /inflightHadFocusRef\.current[\s\S]*?querySelector<HTMLButtonElement>\("\.generate-btn"\)\?\.focus\(\)/);
   assert.match(responsiveCss, /\.mobile-sheet-tabs__button\s*\{[\s\S]*?min-height:\s*44px/);

--- a/ui/src/components/MobileComposeSheet.tsx
+++ b/ui/src/components/MobileComposeSheet.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useModalFocus } from "../hooks/useModalFocus";
 import { useAppStore } from "../store/useAppStore";
 import { useI18n } from "../i18n";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -63,16 +64,12 @@ export function MobileComposeSheet() {
     focusTab(target);
   };
 
+  const sheetRef = useModalFocus<HTMLDivElement>(open, close, { autoFocus: false });
+
   useEffect(() => {
     if (!open || activeTab !== "prompt" || !isMobile || settingsOpen || uiMode !== "classic") {
       setInflightExpanded(false);
     }
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
   }, [open, activeTab, close, isMobile, settingsOpen, uiMode]);
 
   useLayoutEffect(() => {
@@ -122,6 +119,7 @@ export function MobileComposeSheet() {
         />
       ) : null}
       <section
+        ref={sheetRef}
         id="mobile-generate-sheet"
         inert={!open}
         className={`compose-sheet${open ? " compose-sheet--open" : ""}`}

--- a/ui/src/components/PromptImportDialog.tsx
+++ b/ui/src/components/PromptImportDialog.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useCallback, useEffect, useRef, useState, type ChangeEvent, type DragEvent } from "react";
+import { lazy, Suspense, useCallback, useRef, useState, type ChangeEvent, type DragEvent } from "react";
+import { useModalFocus } from "../hooks/useModalFocus";
 import {
   commitPromptImport,
   getPromptImportCuratedSources,
@@ -36,8 +37,7 @@ export function PromptImportDialog({ open, onClose, onImported }: PromptImportDi
   const { t } = useI18n();
   const showToast = useAppStore((s) => s.showToast);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const dialogRef = useModalFocus<HTMLDivElement>(open, onClose);
   const [githubInput, setGithubInput] = useState("");
   const [candidates, setCandidates] = useState<PromptImportCandidate[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -55,13 +55,6 @@ export function PromptImportDialog({ open, onClose, onImported }: PromptImportDi
 
   const hasResults = candidates.length > 0;
   const showUpperSections = !hasResults || forceShowSources;
-
-  useEffect(() => {
-    if (!open) return;
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
-    window.setTimeout(() => dialogRef.current?.focus(), 0);
-    return () => previousFocusRef.current?.focus();
-  }, [open]);
 
   const loadCuratedSources = useCallback(async () => {
     const data = await getPromptImportCuratedSources();
@@ -274,9 +267,6 @@ export function PromptImportDialog({ open, onClose, onImported }: PromptImportDi
         aria-modal="true"
         aria-labelledby="prompt-import-title"
         tabIndex={-1}
-        onKeyDown={(event) => {
-          if (event.key === "Escape") onClose();
-        }}
       >
         <div className="prompt-import-dialog__header">
           <h3 id="prompt-import-title">{t("promptLibrary.importTitle")}</h3>

--- a/ui/src/components/ResultMetadataModal.tsx
+++ b/ui/src/components/ResultMetadataModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useModalFocus } from "../hooks/useModalFocus";
 import { useI18n } from "../i18n";
 import type { GenerateItem } from "../types";
 
@@ -135,6 +136,7 @@ export function ResultMetadataModal({
   onCopy: (value: string) => void;
 }) {
   const { t, locale } = useI18n();
+  const containerRef = useModalFocus<HTMLElement>(true, onClose);
   const rawJson = useMemo(() => JSON.stringify(item, null, 2), [item]);
   const latestContinuity = item.videoContinuity?.entries?.[item.videoContinuity.entries.length - 1] ?? null;
   const provider = providerLabel(item.provider);
@@ -232,7 +234,7 @@ export function ResultMetadataModal({
 
   return (
     <div className="modal-backdrop metadata-modal-backdrop" onClick={onClose}>
-      <section
+      <section ref={containerRef}
         className="modal metadata-modal"
         role="dialog"
         aria-modal="true"

--- a/ui/src/components/UpscalePopover.tsx
+++ b/ui/src/components/UpscalePopover.tsx
@@ -1,5 +1,6 @@
 // wp5 054: upscale parameter popover for image results (video takes none).
 import { useState } from "react";
+import { useModalFocus } from "../hooks/useModalFocus";
 import { upscaleParamsError, type UpscaleParams } from "../lib/upscaleAction";
 import { useI18n } from "../i18n";
 
@@ -14,6 +15,10 @@ const FLAVORS = ["sublime", "photo", "photo_denoiser"] as const;
 
 export function UpscalePopover({ pending, onSubmit, onClose }: Props) {
   const { t } = useI18n();
+  const popoverRef = useModalFocus<HTMLDivElement>(true, onClose, {
+    trap: false,
+    restoreFocus: (reason) => reason !== "outsidePointer",
+  });
   const [scaleFactor, setScaleFactor] = useState<2 | 4 | 8 | 16>(2);
   const [flavor, setFlavor] = useState<"sublime" | "photo" | "photo_denoiser" | "">("");
   const [sharpen, setSharpen] = useState(10);
@@ -28,7 +33,7 @@ export function UpscalePopover({ pending, onSubmit, onClose }: Props) {
   const error = upscaleParamsError("image", params);
 
   return (
-    <div className="upscale-popover" role="dialog" aria-label={t("result.upscaleTitle")}>
+    <div ref={popoverRef} className="upscale-popover" role="dialog" aria-label={t("result.upscaleTitle")}>
       <div className="option-row" role="group" aria-label="scaleFactor">
         {SCALE_FACTORS.map((value) => (
           <button key={value} type="button"

--- a/ui/src/components/agent/useAgentDialogFocus.ts
+++ b/ui/src/components/agent/useAgentDialogFocus.ts
@@ -1,55 +1,12 @@
-import { useEffect, useRef } from "react";
-
-const FOCUSABLE =
-  'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
+import { useModalFocus } from "../../hooks/useModalFocus";
 
 type Options = {
-  // Non-modal panels leave the rest of the workspace usable, so they must not
-  // cycle Tab back into themselves (WAI-ARIA APG: only modal dialogs trap
-  // focus). Escape still closes, and focus still returns to the trigger.
   modal?: boolean;
 };
 
+/** Thin wrapper — delegates to the shared modal-focus stack. */
 export function useAgentDialogFocus(open: boolean, onClose: () => void, options: Options = {}) {
-  const modal = options.modal !== false;
-  const panelRef = useRef<HTMLDivElement>(null);
-  const restoreRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    restoreRef.current = document.activeElement as HTMLElement | null;
-    const focusTimer = window.setTimeout(() => {
-      const panel = panelRef.current;
-      if (!panel) return;
-      const heading = panel.querySelector<HTMLElement>("[data-autofocus]");
-      (heading ?? panel.querySelector<HTMLElement>(FOCUSABLE))?.focus();
-    }, 0);
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-      if (!modal || event.key !== "Tab") return;
-      const nodes = Array.from(panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
-      if (nodes.length === 0) return;
-      const first = nodes[0];
-      const last = nodes[nodes.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.clearTimeout(focusTimer);
-      document.removeEventListener("keydown", onKeyDown);
-      restoreRef.current?.focus();
-    };
-  }, [modal, onClose, open]);
-
-  return panelRef;
+  return useModalFocus<HTMLDivElement>(open, onClose, {
+    trap: options.modal !== false,
+  });
 }

--- a/ui/src/components/assetgen/KeyingPanel.tsx
+++ b/ui/src/components/assetgen/KeyingPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useI18n } from "../../i18n";
+import { useModalFocus } from "../../hooks/useModalFocus";
 import { useAppStore } from "../../store/useAppStore";
 import { uploadDerivedAsset, requestVideoKeying } from "../../lib/api-assets";
 import { subscribe } from "../../lib/eventChannel";
@@ -40,6 +41,7 @@ export function KeyingPanel() {
   const { t } = useI18n();
   const item = useAppStore((s) => s.keyingTarget);
   const close = useAppStore((s) => s.setKeyingTarget);
+  const dialogRef = useModalFocus<HTMLDivElement>(!!item, () => close(null));
   const addDerivedItem = useAppStore((s) => s.addAssetGenDerivedItem);
   const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const showToast = useAppStore((s) => s.showToast);
@@ -275,19 +277,11 @@ export function KeyingPanel() {
     }, "image/png");
   }, [item, saving, isVideo, keyColor, selectedProjectId, tolerance, softness, spill, clearKeyingSubscription, addDerivedItem, showToast, close, t]);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close(null);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [close]);
-
   if (!item) return null;
 
   return (
     <div className="assetgen-popup-backdrop" onClick={() => close(null)}>
-      <div className="keying-panel" role="dialog" aria-modal="true" aria-label={t("keying.title")} onClick={(e) => e.stopPropagation()}>
+      <div ref={dialogRef} className="keying-panel" role="dialog" aria-modal="true" aria-label={t("keying.title")} onClick={(e) => e.stopPropagation()}>
         <header className="keying-panel__head">
           <h2>{t("keying.title")}</h2>
           {keyColor ? (

--- a/ui/src/components/assetgen/ProjectSearchPopup.tsx
+++ b/ui/src/components/assetgen/ProjectSearchPopup.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useI18n } from "../../i18n";
+import { useModalFocus } from "../../hooks/useModalFocus";
 import { useAppStore } from "../../store/useAppStore";
 
 type Props = { onClose: () => void; onSelect: (id: string | null) => void };
@@ -9,15 +10,7 @@ export function ProjectSearchPopup({ onClose, onSelect }: Props) {
   const folders = useAppStore((s) => s.assetsFolders);
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    inputRef.current?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const dialogRef = useModalFocus<HTMLDivElement>(true, onClose);
 
   const results = useMemo(() => {
     const roots = folders.filter((f) => f.parentId === null);
@@ -27,7 +20,7 @@ export function ProjectSearchPopup({ onClose, onSelect }: Props) {
 
   return (
     <div className="assetgen-popup-backdrop" onClick={onClose}>
-      <div
+      <div ref={dialogRef}
         className="assetgen-popup"
         role="dialog"
         aria-modal="true"

--- a/ui/src/components/assetgen/SpriteAnchorGate.tsx
+++ b/ui/src/components/assetgen/SpriteAnchorGate.tsx
@@ -1,2 +1,54 @@
-import { useState } from "react"; import { useI18n } from "../../i18n"; import type { SpriteAnchorCandidate, SpriteRecipeRecord } from "../../types/spriteRecipe";
-export function SpriteAnchorGate({ recipe, candidate, generating, onGenerate, onApprove }: { recipe: SpriteRecipeRecord; candidate: SpriteAnchorCandidate | null; generating: boolean; onGenerate(): void; onApprove(assetId: string): void }) { const { t } = useI18n(); const [confirm, setConfirm] = useState(false); return <section className="sprite-anchor-gate" aria-labelledby="sprite-anchor-title"><h2 id="sprite-anchor-title">{t("sprite.anchor.title")}</h2>{candidate ? <><img src={candidate.url} alt="" /><p>{t("sprite.anchor.candidate")}</p><button onClick={onGenerate} disabled={generating}>{t("sprite.anchor.regenerate")}</button><button onClick={() => setConfirm(true)}>{t("sprite.anchor.approve")}</button></> : <><p>{t(recipe.anchorStatus === "approved" ? "sprite.anchor.approved" : "sprite.anchor.missing")}</p><button onClick={onGenerate} disabled={generating}>{t(generating ? "sprite.anchor.generating" : "sprite.anchor.generate")}</button></>}{confirm ? <div className="sprite-anchor-dialog" role="dialog" aria-modal="true" aria-labelledby="sprite-confirm-title"><h3 id="sprite-confirm-title">{t("sprite.anchor.confirmTitle")}</h3><p>{t("sprite.anchor.confirmBody")}</p><button onClick={() => setConfirm(false)}>{t("sprite.anchor.cancel")}</button><button onClick={() => { onApprove(candidate!.assetId); setConfirm(false); }}>{t("sprite.anchor.confirm")}</button></div> : null}</section>; }
+import { useState } from "react";
+import { useI18n } from "../../i18n";
+import { useModalFocus } from "../../hooks/useModalFocus";
+import type { SpriteAnchorCandidate, SpriteRecipeRecord } from "../../types/spriteRecipe";
+
+function ConfirmDialog({ onCancel, onConfirm }: { onCancel: () => void; onConfirm: () => void }) {
+  const { t } = useI18n();
+  const ref = useModalFocus<HTMLDivElement>(true, onCancel);
+  return (
+    <div className="sprite-anchor-dialog" role="dialog" aria-modal="true" aria-labelledby="sprite-confirm-title" ref={ref}>
+      <h3 id="sprite-confirm-title">{t("sprite.anchor.confirmTitle")}</h3>
+      <p>{t("sprite.anchor.confirmBody")}</p>
+      <button data-modal-initial-focus onClick={onCancel}>{t("sprite.anchor.cancel")}</button>
+      <button onClick={onConfirm}>{t("sprite.anchor.confirm")}</button>
+    </div>
+  );
+}
+
+export function SpriteAnchorGate({ recipe, candidate, generating, onGenerate, onApprove }: {
+  recipe: SpriteRecipeRecord;
+  candidate: SpriteAnchorCandidate | null;
+  generating: boolean;
+  onGenerate(): void;
+  onApprove(assetId: string): void;
+}) {
+  const { t } = useI18n();
+  const [confirm, setConfirm] = useState(false);
+  return (
+    <section className="sprite-anchor-gate" aria-labelledby="sprite-anchor-title">
+      <h2 id="sprite-anchor-title">{t("sprite.anchor.title")}</h2>
+      {candidate ? (
+        <>
+          <img src={candidate.url} alt="" />
+          <p>{t("sprite.anchor.candidate")}</p>
+          <button onClick={onGenerate} disabled={generating}>{t("sprite.anchor.regenerate")}</button>
+          <button onClick={() => setConfirm(true)}>{t("sprite.anchor.approve")}</button>
+        </>
+      ) : (
+        <>
+          <p>{t(recipe.anchorStatus === "approved" ? "sprite.anchor.approved" : "sprite.anchor.missing")}</p>
+          <button onClick={onGenerate} disabled={generating}>
+            {t(generating ? "sprite.anchor.generating" : "sprite.anchor.generate")}
+          </button>
+        </>
+      )}
+      {confirm ? (
+        <ConfirmDialog
+          onCancel={() => setConfirm(false)}
+          onConfirm={() => { onApprove(candidate!.assetId); setConfirm(false); }}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/ui/src/components/assets/AssetsWorkspace.tsx
+++ b/ui/src/components/assets/AssetsWorkspace.tsx
@@ -12,52 +12,13 @@ import { AssetMediaLightbox } from "../assetgen/AssetMediaLightbox";
 import { KeyingPanel } from "../assetgen/KeyingPanel";
 import { AssetsFolderTree } from "./AssetsFolderTree";
 import { AssetsGrid } from "./AssetsGrid";
+import { useModalFocus } from "../../hooks/useModalFocus";
 import { ElementDetail, type ElementDefinition, type ElementDraft } from "./ElementDetail";
 
 const kinds = ["image", "video", "element", "preset", "template"] as const;
 type KindValue = "" | typeof kinds[number];
-const ASSET_DETAIL_FOCUSABLE = 'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
-
 function useMobileAssetDetailDialog(open: boolean, onClose: () => void) {
-  const panelRef = useRef<HTMLElement>(null);
-  const restoreRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    restoreRef.current = document.activeElement as HTMLElement | null;
-    const focusTimer = window.setTimeout(() => {
-      panelRef.current?.querySelector<HTMLElement>(ASSET_DETAIL_FOCUSABLE)?.focus();
-    }, 0);
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const nodes = Array.from(
-        panelRef.current?.querySelectorAll<HTMLElement>(ASSET_DETAIL_FOCUSABLE) ?? [],
-      ).filter((node) => !node.hasAttribute("disabled") && node.getClientRects().length > 0);
-      if (nodes.length === 0) return;
-      const first = nodes[0];
-      const last = nodes[nodes.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.clearTimeout(focusTimer);
-      document.removeEventListener("keydown", onKeyDown);
-      restoreRef.current?.focus();
-    };
-  }, [onClose, open]);
-
-  return panelRef;
+  return useModalFocus<HTMLElement>(open, onClose);
 }
 
 export function AssetsWorkspace() {

--- a/ui/src/components/canvas-mode/CanvasStylePopover.tsx
+++ b/ui/src/components/canvas-mode/CanvasStylePopover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useModalFocus, type CloseReason } from "../../hooks/useModalFocus";
 import type { CanvasAnnotationStyle } from "../../types/canvas";
 import { CANVAS_STROKE_WIDTHS, CANVAS_STYLE_COLORS } from "../../hooks/useCanvasAnnotations";
 import { useI18n } from "../../i18n";
@@ -11,6 +12,9 @@ interface CanvasStylePopoverProps {
 export function CanvasStylePopover({ style, onStyleChange }: CanvasStylePopoverProps) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
+  const popoverRef = useModalFocus<HTMLDivElement>(open, (reason?: CloseReason) => {
+    setOpen(false);
+  }, { trap: false, restoreFocus: (reason) => reason !== "outsidePointer" });
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -26,13 +30,6 @@ export function CanvasStylePopover({ style, onStyleChange }: CanvasStylePopoverP
     <div
       ref={ref}
       className={`canvas-toolbar__split-button${open ? " canvas-toolbar__split-button--active" : ""}`}
-      onKeyDown={(event) => {
-        if (event.key === "Escape" && open) {
-          event.preventDefault();
-          event.stopPropagation();
-          setOpen(false);
-        }
-      }}
     >
       <button
         type="button"
@@ -55,7 +52,7 @@ export function CanvasStylePopover({ style, onStyleChange }: CanvasStylePopoverP
         />
       </button>
       {open ? (
-        <div className="canvas-style-popover" role="dialog" aria-label={t("canvas.toolbar.style")}>
+        <div ref={popoverRef} className="canvas-style-popover" role="dialog" aria-label={t("canvas.toolbar.style")}>
           <div
             className="canvas-style-popover__row"
             role="group"

--- a/ui/src/components/node-canvas/NodeStudioOverlays.tsx
+++ b/ui/src/components/node-canvas/NodeStudioOverlays.tsx
@@ -1,6 +1,7 @@
-import { useRef, type KeyboardEvent, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Panel } from "@xyflow/react";
 import { useI18n } from "../../i18n";
+import { useModalFocus } from "../../hooks/useModalFocus";
 import type { useNodeStudioController } from "./useNodeStudioController";
 import { NodeBranchDialog } from "./NodeBranchDialog";
 import { NodeCommandPalette } from "./NodeCommandPalette";
@@ -16,22 +17,9 @@ export interface NodeStudioOverlaysProps {
   onAddRoot(): void;
 }
 
-function focusable(root: HTMLElement): HTMLElement[] {
-  return [...root.querySelectorAll<HTMLElement>("button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex='-1'])")];
-}
-
 function DialogFrame({ children, onClose }: { children: ReactNode; onClose(): void }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); onClose(); return; }
-    if (event.key !== "Tab" || !ref.current) return;
-    const items = focusable(ref.current);
-    if (!items.length) return;
-    const first = items[0]; const last = items[items.length - 1];
-    if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
-    else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
-  };
-  return <div ref={ref} className="node-studio-dialog-backdrop" onKeyDown={onKeyDown} onPointerDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>{children}</div>;
+  const ref = useModalFocus<HTMLDivElement>(true, onClose);
+  return <div ref={ref} className="node-studio-dialog-backdrop" onPointerDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>{children}</div>;
 }
 
 export function NodeStudioOverlays({ studio, graphEmpty, disabled, onAddRoot }: NodeStudioOverlaysProps) {

--- a/ui/src/hooks/useModalFocus.ts
+++ b/ui/src/hooks/useModalFocus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useId, useRef, type RefObject } from "react";
 
 const FOCUSABLE = [
   "a[href]",
@@ -9,16 +9,38 @@ const FOCUSABLE = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(",");
 
+/* ---- Modal stack: only the topmost entry receives Escape and Tab ---- */
+const modalStack: string[] = [];
+function isTopmost(id: string): boolean {
+  return modalStack.length > 0 && modalStack[modalStack.length - 1] === id;
+}
+
+export type CloseReason = "escape" | "closeButton" | "outsidePointer" | "programmatic";
+
+export interface ModalFocusOptions {
+  /** Set false for non-modal panels that should not trap Tab. Default true. */
+  trap?: boolean;
+  /** Set false to skip auto-focus on open. Default true. */
+  autoFocus?: boolean;
+  /** Control whether focus returns to the trigger on close. Default true.
+      Can be a predicate receiving the close reason. */
+  restoreFocus?: boolean | ((reason: CloseReason) => boolean);
+}
+
 export function useModalFocus<T extends HTMLElement>(
   open: boolean,
-  onClose: () => void,
+  onClose: (reason?: CloseReason) => void,
+  options: ModalFocusOptions = {},
 ): RefObject<T | null> {
   const containerRef = useRef<T>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const stackId = useId();
+  const { trap = true, autoFocus = true, restoreFocus = true } = options;
 
   useEffect(() => {
     if (!open) return;
+    modalStack.push(stackId);
     const previousFocus = document.activeElement instanceof HTMLElement
       ? document.activeElement
       : null;
@@ -27,20 +49,28 @@ export function useModalFocus<T extends HTMLElement>(
       container?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
     ).filter((element) => !element.hidden && element.getAttribute("aria-hidden") !== "true");
 
-    window.requestAnimationFrame(() => {
-      const initial = container?.querySelector<HTMLElement>("[data-modal-initial-focus]")
-        ?? focusable()[0]
-        ?? container;
-      initial?.focus();
-    });
+    if (autoFocus) {
+      window.requestAnimationFrame(() => {
+        const initial = container?.querySelector<HTMLElement>("[data-modal-initial-focus]")
+          ?? focusable()[0]
+          ?? container;
+        initial?.focus();
+      });
+    }
+
+    const shouldRestore = (reason: CloseReason): boolean => {
+      if (typeof restoreFocus === "function") return restoreFocus(reason);
+      return restoreFocus;
+    };
 
     const onKeyDown = (event: KeyboardEvent) => {
+      if (!isTopmost(stackId)) return;
       if (event.key === "Escape") {
         event.preventDefault();
-        onCloseRef.current();
+        onCloseRef.current("escape");
         return;
       }
-      if (event.key !== "Tab") return;
+      if (!trap || event.key !== "Tab") return;
       const elements = focusable();
       if (elements.length === 0) {
         event.preventDefault();
@@ -59,11 +89,21 @@ export function useModalFocus<T extends HTMLElement>(
     };
 
     document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      window.requestAnimationFrame(() => previousFocus?.focus());
+    let closeReason: CloseReason = "programmatic";
+    const origClose = onCloseRef.current;
+    onCloseRef.current = (reason?: CloseReason) => {
+      closeReason = reason ?? "programmatic";
+      origClose(reason);
     };
-  }, [open]);
+    return () => {
+      const idx = modalStack.indexOf(stackId);
+      if (idx !== -1) modalStack.splice(idx, 1);
+      document.removeEventListener("keydown", onKeyDown);
+      if (shouldRestore(closeReason)) {
+        window.requestAnimationFrame(() => previousFocus?.focus());
+      }
+    };
+  }, [open, stackId, trap, autoFocus, restoreFocus]);
 
   return containerRef;
 }


### PR DESCRIPTION
## Summary

Introduces a modal stack in useModalFocus so only the topmost dialog receives
Escape and Tab cycling. Consolidates 10 components onto the shared hook,
eliminating duplicate focus management code.

### useModalFocus enhancements
- Modal stack: multiple dialogs stack correctly, Escape closes topmost only
- CloseReason type: escape/closeButton/outsidePointer/programmatic
- Options: trap (default true), autoFocus (default true), restoreFocus (boolean or predicate)

### Components migrated
**A-table (no prior focus management):** ResultMetadataModal, SpriteAnchorGate,
KeyingPanel, CanvasStylePopover (non-modal), UpscalePopover (non-modal)

**B-table (partial implementations replaced):** PromptImportDialog,
MobileComposeSheet, ProjectSearchPopup, AssetsWorkspace, NodeStudioOverlays

### useAgentDialogFocus
Now a 3-line wrapper delegating to useModalFocus with trap option.

### Tests
- 4 contract tests updated for shared-hook delegation
- Full suite: 2732 pass / 0 fail / 2 skipped
- Net -29 lines across 16 files