### PR TITLE
refactor(providers): adapter-owned execution for legacy lanes (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Provider Adapter v1 execution hook** (#150) — `ProviderAdapterV1` gains an optional `prepareImageExecution` and the NovelAI, MiniMax, Atlas Cloud and ComfyUI adapters now own their classic/node/edit/multimode dispatch; `prepareImageExecution` routes to a registered adapter before the legacy lane switches, which are reduced to their unsupported-surface refusals. Descriptor adapters for `api`, `grok-api` and `gemini-api` (API key or Vertex service account) join the common contract suite; `oauth`, `grok` and `agy` stay unregistered because their readiness is asynchronous.
+
 ### Fixed
 
 - Removed no-op `catch (error) { throw error; }` wrappers across provider execution, sprite, asset and LAN-session modules; behavior is unchanged and the coding convention now asks for try/catch only where an error is transformed, logged, or surfaced at a boundary.

--- a/devlog/_plan/260908_post_314_cleanup/040_wp4_adapter_v1.md
+++ b/devlog/_plan/260908_post_314_cleanup/040_wp4_adapter_v1.md
@@ -68,3 +68,22 @@ Close #150 only if all six rows are met. Expected after wp4: rows 1-2 met, row 3
 touches registry + adapter file + keys/UI; measure by listing files a hypothetical
 "lane X" needs), rows 5-6 not met -> leave OPEN with the fresh table and residual list.
 
+
+## wp4 P revalidation (2026-09-08, tree a2de1110 = origin/dev after wp1-wp3)
+Quoting wp3 D: #193 shipped and closed; direction unchanged.
+Re-anchored after the wp1 rethrow removal: legacyClassic.ts branch lines 24-55 (throw at :55),
+legacyNode.ts :47, legacyEdit.ts :21, legacyMultimode.ts :20; execution/index.ts prepareSelected
+at :11-18 (no try wrappers now). registry errorPrefix: api null, grok-api "GROK_", gemini-api
+"GEMINI_API_" — the contract suite's normalizeError test skips lanes with a null prefix, so
+api.ts still returns { code, message, status?, retryable } with the raw code or "UNKNOWN".
+tests/provider-execution-boundary.test.ts:230 asserts the legacy "Unsupported" refusal is
+raised inside execute() with zero adapter calls; the adapter hooks must keep that shape, and
+the legacy files keep the throw for lanes that fall through (probe.source lists which lanes
+each surface supports).
+Write lanes: A (adapters + execution): lib/providers/adapters/{api,grok-api,gemini-api}.ts new,
+adapters/{index,types,nai,minimax,atlascloud,comfy}.ts, lib/providers/execution/{index,
+legacyClassic,legacyNode,legacyEdit,legacyMultimode}.ts, tests/provider-adapter-v1-contract.test.ts,
+tests/nai-routing-contract.test.ts, tests/_executionImportEdges.mjs,
+tests/provider-execution-imports.test.ts. Single lane: the edits are tightly coupled
+(hook type -> adapters -> execution dispatch -> import policy), so one worker owns them.
+

--- a/lib/providers/adapters/api.ts
+++ b/lib/providers/adapters/api.ts
@@ -1,0 +1,65 @@
+/** OpenAI descriptor adapter; execution stays with its typed family owner. */
+import type { RuntimeContext } from "../../runtimeContext.js";
+import { getProvider } from "../registry.js";
+import type { CoreProviderModel } from "../types.js";
+import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
+
+const LANE_ID = "api" as const;
+const ERROR_PREFIX = getProvider(LANE_ID).errorPrefix;
+
+/** Status codes worth retrying: transient upstream conditions, not bad input. */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function readStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return typeof candidate.status === "number" ? candidate.status
+    : typeof candidate.statusCode === "number" ? candidate.statusCode
+    : undefined;
+}
+
+function readCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { code?: unknown };
+  return typeof candidate.code === "string" ? candidate.code : undefined;
+}
+
+export function createApiAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
+  return {
+    laneId: LANE_ID,
+
+    validateAuth(): AuthResult {
+      return ctx.apiKey
+        ? { ok: true }
+        : { ok: false, reason: "OpenAI API key missing" };
+    },
+
+    listModels(): readonly CoreProviderModel[] {
+      // Straight from the registry. A hand-written list here is exactly the
+      // drift the capability registry was built to remove.
+      return getProvider(LANE_ID).models;
+    },
+
+    normalizeError(error: unknown): ProviderError {
+      const status = readStatus(error);
+      const rawCode = readCode(error);
+      const message = error instanceof Error ? error.message
+        : typeof error === "string" ? error
+        : "OpenAI request failed";
+      const code = !ERROR_PREFIX
+        ? rawCode ?? "UNKNOWN"
+        : rawCode?.startsWith(ERROR_PREFIX)
+          ? rawCode
+          : rawCode
+            ? `${ERROR_PREFIX}${rawCode}`
+            : `${ERROR_PREFIX}UNKNOWN`;
+      const retryable = status === undefined ? false : RETRYABLE_STATUSES.has(status);
+      return {
+        code,
+        message,
+        ...(status === undefined ? {} : { status }),
+        retryable,
+      };
+    },
+  };
+}

--- a/lib/providers/adapters/atlascloud.ts
+++ b/lib/providers/adapters/atlascloud.ts
@@ -1,17 +1,14 @@
 /**
- * Atlas Cloud adapter (#150, phase 2 — the second adapter).
- *
- * Atlas Cloud is the second lane behind ProviderAdapterV1 because it is the
- * only remaining lane with exactly one API key, a unique error prefix, image-
- * only models, and synchronously readable auth state. gemini-api carries two
- * credentials (a multi-credential AuthResult design question), agy's auth
- * comes from async binary detection, grok-api shares its error prefix with
- * grok, and oauth/api have no prefix for the contract suite to assert on.
- *
- * This wraps the existing runtime; it does not move it. lib/atlasCloudImageAdapter
- * keeps generating images exactly as before.
+ * Atlas Cloud adapter: readiness, registry models, errors and image execution surfaces.
+ * The existing image adapter retains transport and provider protocol ownership.
  */
-import type { RuntimeContext } from "../../runtimeContext.js";
+import { generateViaAtlasCloud } from "../../atlasCloudImageAdapter.js";
+import type {
+  ExecutionProgress, ExecutionSurface, ImageExecutionRequest, PreparedImageExecution,
+} from "../execution/types.js";
+import { detectImageMimeFromB64 } from "../../refs.js";
+import type { ImageBackgroundParams } from "../../imageBackgroundParam.js";
+import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
 import { getProvider } from "../registry.js";
 import type { CoreProviderModel } from "../types.js";
 import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
@@ -47,6 +44,7 @@ function readCode(error: unknown): string | undefined {
 export function createAtlasCloudAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
   return {
     laneId: LANE_ID,
+    prepareImageExecution: prepareLaneImageExecution,
 
     validateAuth(): AuthResult {
       // Presence only, and note the spelling: the context field is
@@ -82,4 +80,80 @@ export function createAtlasCloudAdapter(ctx: RuntimeContext): ProviderAdapterV1 
       };
     },
   };
+}
+
+function prepareClassic(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "classic" }>,
+): PreparedImageExecution<"classic"> {
+  const { prompt: generationPrompt, requestId, background: backgroundParams } = request;
+  const { model: imageModel, size: effectiveSize, quality } = request.options;
+  // Capture scalars/background at prepare; ctx, refs, signal and lane options stay live.
+  return { execute: async () => {
+    const value = await generateViaAtlasCloud(generationPrompt, requireRuntimeContext(ctx), {
+      model: imageModel, size: effectiveSize, quality, signal: request.signal,
+      requestId, references: request.references,
+      ...(backgroundParams ? { background: backgroundParams.background } : {}),
+      // The caller's resolveImageBackgroundParams validates this alpha-only format.
+      ...(backgroundParams?.outputFormat ? { outputFormat: backgroundParams.outputFormat as ImageBackgroundParams["outputFormat"] } : {}),
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareNode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "node" }>,
+): PreparedImageExecution<"node"> {
+  return { execute: async () => {
+    const { sourceImage: parentB64, rawPrompt: prompt, references, requestId, signal, options } = request;
+    const { model, size, quality } = options;
+    const value = await generateViaAtlasCloud(parentB64 ? `Edit this image: ${prompt}` : prompt, requireRuntimeContext(ctx), {
+      model, size, quality, signal, requestId,
+      references: parentB64
+        ? [{ b64: parentB64, declaredMime: null, detectedMime: null }, ...references]
+        : references,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareEdit(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "edit" }>,
+): PreparedImageExecution<"edit"> {
+  return { execute: async () => {
+    const { prompt, sourceImage, signal, requestId, options } = request;
+    const references = [{ b64: sourceImage, declaredMime: null, detectedMime: detectImageMimeFromB64(sourceImage) || null }];
+    const editPrompt = `Edit this image: ${prompt}`;
+    const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
+    const value = await generateViaAtlasCloud(editPrompt, ctx, { ...params, quality: options.quality });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareMultimode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "multimode" }>,
+): PreparedImageExecution<"multimode"> {
+  return { execute: async () => {
+    const { rawPrompt, references, signal, requestId, options } = request;
+    const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
+    const result = await generateViaAtlasCloud(rawPrompt, ctx, { ...params, quality: options.quality });
+    // Preserve the projection; the caller owns the final persistence sweep.
+    return { kind: "sequence", value: {
+      images: [{ b64: result.b64, ...(result.revisedPrompt !== undefined ? { revisedPrompt: result.revisedPrompt } : {}) }],
+      usage: result.usage, webSearchCalls: result.webSearchCalls,
+    } };
+  } };
+}
+
+function prepareLaneImageExecution<R extends ImageExecutionRequest>(
+  ctx: RuntimeContext, request: R, progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<R["surface"]>>;
+async function prepareLaneImageExecution(
+  ctx: RuntimeContext, request: ImageExecutionRequest, _progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<ExecutionSurface>> {
+  switch (request.surface) {
+    case "classic": return prepareClassic(ctx, request);
+    case "node": return prepareNode(ctx, request);
+    case "edit": return prepareEdit(ctx, request);
+    case "multimode": return prepareMultimode(ctx, request);
+  }
 }

--- a/lib/providers/adapters/comfy.ts
+++ b/lib/providers/adapters/comfy.ts
@@ -15,7 +15,12 @@
  * use this projection: lib/comfyImageAdapter reads the store directly, so a
  * context lagging one write can never run a stale graph.
  */
-import type { RuntimeContext } from "../../runtimeContext.js";
+import { generateViaComfy } from "../../comfyImageAdapter.js";
+import type {
+  ExecutionProgress, ExecutionSurface, ImageExecutionRequest, PreparedImageExecution,
+} from "../execution/types.js";
+import { detectImageMimeFromB64 } from "../../refs.js";
+import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
 import type { CoreProviderModel } from "../types.js";
 import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
 
@@ -42,6 +47,7 @@ function readCode(error: unknown): string | undefined {
 export function createComfyAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
   return {
     laneId: LANE_ID,
+    prepareImageExecution: prepareLaneImageExecution,
 
     validateAuth(): AuthResult {
       const workflows = (ctx.comfyWorkflows ?? []).filter((workflow) => workflow.mediaKind !== "video");
@@ -68,24 +74,73 @@ export function createComfyAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
         }));
     },
 
-    normalizeError(error: unknown): ProviderError {
-      const status = readStatus(error);
-      const rawCode = readCode(error);
-      const message = error instanceof Error ? error.message
-        : typeof error === "string" ? error
-        : "ComfyUI request failed";
-      const code = rawCode?.startsWith(ERROR_PREFIX)
-        ? rawCode
-        : rawCode
-          ? `${ERROR_PREFIX}${rawCode}`
-          : `${ERROR_PREFIX}UNKNOWN`;
-      const retryable = status === undefined ? false : RETRYABLE_STATUSES.has(status);
-      return {
-        code,
-        message,
-        ...(status === undefined ? {} : { status }),
-        retryable,
-      };
-    },
+    normalizeError,
+  };
+}
+
+function prepareClassic(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "classic" }>, progress: ExecutionProgress,
+): PreparedImageExecution<"classic"> {
+  const { prompt: generationPrompt, requestId } = request;
+  const { model: imageModel, size: effectiveSize } = request.options;
+  // Capture scalars at prepare; ctx, refs, signal and lane options stay live.
+  return { execute: async () => {
+    const value = await generateViaComfy(generationPrompt, requireRuntimeContext(ctx), {
+      model: imageModel, size: effectiveSize, signal: request.signal,
+      requestId, references: request.references,
+      ...request.comfy, onQueue: progress.onQueue,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareEdit(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "edit" }>,
+): PreparedImageExecution<"edit"> {
+  return { execute: async () => {
+    const { prompt, sourceImage, signal, requestId, options } = request;
+    const references = [{ b64: sourceImage, declaredMime: null, detectedMime: detectImageMimeFromB64(sourceImage) || null }];
+    const editPrompt = `Edit this image: ${prompt}`;
+    const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
+    const value = await generateViaComfy(editPrompt, ctx, params);
+    return { kind: "single", value };
+  } };
+}
+
+function prepareLaneImageExecution<R extends ImageExecutionRequest>(
+  ctx: RuntimeContext, request: R, progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<R["surface"]>>;
+async function prepareLaneImageExecution(
+  ctx: RuntimeContext, request: ImageExecutionRequest, progress: ExecutionProgress = {},
+): Promise<PreparedImageExecution<ExecutionSurface>> {
+  switch (request.surface) {
+    case "classic": return prepareClassic(ctx, request, progress);
+    case "node": return { execute: async () => {
+      throw new Error(`Unsupported node execution provider: ${request.provider}`);
+    } };
+    case "edit": return prepareEdit(ctx, request);
+    case "multimode": return { execute: async () => {
+      throw new Error(`Unsupported legacy multimode provider: ${request.provider}`);
+    } };
+  }
+}
+
+function normalizeError(error: unknown): ProviderError {
+  const status = readStatus(error);
+  const rawCode = readCode(error);
+  const message = error instanceof Error ? error.message
+    : typeof error === "string" ? error
+    : "ComfyUI request failed";
+  const code = rawCode?.startsWith(ERROR_PREFIX)
+    ? rawCode
+    : rawCode
+      ? `${ERROR_PREFIX}${rawCode}`
+      : `${ERROR_PREFIX}UNKNOWN`;
+  const retryable = status === undefined ? false : RETRYABLE_STATUSES.has(status);
+  return {
+    code,
+    message,
+    ...(status === undefined ? {} : { status }),
+    retryable,
   };
 }

--- a/lib/providers/adapters/gemini-api.ts
+++ b/lib/providers/adapters/gemini-api.ts
@@ -1,0 +1,65 @@
+/** Gemini API descriptor adapter; execution stays with its typed family owner. */
+import type { RuntimeContext } from "../../runtimeContext.js";
+import { getProvider } from "../registry.js";
+import type { CoreProviderModel } from "../types.js";
+import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
+
+const LANE_ID = "gemini-api" as const;
+const ERROR_PREFIX = getProvider(LANE_ID).errorPrefix;
+
+/** Status codes worth retrying: transient upstream conditions, not bad input. */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function readStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return typeof candidate.status === "number" ? candidate.status
+    : typeof candidate.statusCode === "number" ? candidate.statusCode
+    : undefined;
+}
+
+function readCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { code?: unknown };
+  return typeof candidate.code === "string" ? candidate.code : undefined;
+}
+
+export function createGeminiApiAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
+  return {
+    laneId: LANE_ID,
+
+    validateAuth(): AuthResult {
+      return ctx.geminiApiKey || ctx.vertexServiceAccountJson
+        ? { ok: true }
+        : { ok: false, reason: "Gemini API key or Vertex service account missing" };
+    },
+
+    listModels(): readonly CoreProviderModel[] {
+      // Straight from the registry. A hand-written list here is exactly the
+      // drift the capability registry was built to remove.
+      return getProvider(LANE_ID).models;
+    },
+
+    normalizeError(error: unknown): ProviderError {
+      const status = readStatus(error);
+      const rawCode = readCode(error);
+      const message = error instanceof Error ? error.message
+        : typeof error === "string" ? error
+        : "Gemini API request failed";
+      const code = !ERROR_PREFIX
+        ? rawCode ?? "UNKNOWN"
+        : rawCode?.startsWith(ERROR_PREFIX)
+          ? rawCode
+          : rawCode
+            ? `${ERROR_PREFIX}${rawCode}`
+            : `${ERROR_PREFIX}UNKNOWN`;
+      const retryable = status === undefined ? false : RETRYABLE_STATUSES.has(status);
+      return {
+        code,
+        message,
+        ...(status === undefined ? {} : { status }),
+        retryable,
+      };
+    },
+  };
+}

--- a/lib/providers/adapters/grok-api.ts
+++ b/lib/providers/adapters/grok-api.ts
@@ -1,0 +1,65 @@
+/** xAI descriptor adapter; execution stays with its typed family owner. */
+import type { RuntimeContext } from "../../runtimeContext.js";
+import { getProvider } from "../registry.js";
+import type { CoreProviderModel } from "../types.js";
+import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
+
+const LANE_ID = "grok-api" as const;
+const ERROR_PREFIX = getProvider(LANE_ID).errorPrefix;
+
+/** Status codes worth retrying: transient upstream conditions, not bad input. */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function readStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return typeof candidate.status === "number" ? candidate.status
+    : typeof candidate.statusCode === "number" ? candidate.statusCode
+    : undefined;
+}
+
+function readCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { code?: unknown };
+  return typeof candidate.code === "string" ? candidate.code : undefined;
+}
+
+export function createGrokApiAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
+  return {
+    laneId: LANE_ID,
+
+    validateAuth(): AuthResult {
+      return ctx.xaiApiKey
+        ? { ok: true }
+        : { ok: false, reason: "xAI API key missing" };
+    },
+
+    listModels(): readonly CoreProviderModel[] {
+      // Straight from the registry. A hand-written list here is exactly the
+      // drift the capability registry was built to remove.
+      return getProvider(LANE_ID).models;
+    },
+
+    normalizeError(error: unknown): ProviderError {
+      const status = readStatus(error);
+      const rawCode = readCode(error);
+      const message = error instanceof Error ? error.message
+        : typeof error === "string" ? error
+        : "xAI request failed";
+      const code = !ERROR_PREFIX
+        ? rawCode ?? "UNKNOWN"
+        : rawCode?.startsWith(ERROR_PREFIX)
+          ? rawCode
+          : rawCode
+            ? `${ERROR_PREFIX}${rawCode}`
+            : `${ERROR_PREFIX}UNKNOWN`;
+      const retryable = status === undefined ? false : RETRYABLE_STATUSES.has(status);
+      return {
+        code,
+        message,
+        ...(status === undefined ? {} : { status }),
+        retryable,
+      };
+    },
+  };
+}

--- a/lib/providers/adapters/index.ts
+++ b/lib/providers/adapters/index.ts
@@ -1,12 +1,13 @@
 /**
- * Adapter lookup (#150, phase 2).
- *
- * MiniMax (phase 1 reference) and Atlas Cloud (second adapter) are registered.
- * Every other lane returns null and keeps its current code path, so each
- * migration is a deliberate, measured step rather than a bulk rewrite.
+ * Adapter lookup (#150): seven lanes expose synchronous readiness and metadata.
+ * NAI, MiniMax, Atlas Cloud and Comfy also own their image execution surfaces.
+ * OAuth, Grok proxy and Antigravity await an async readiness contract.
  */
 import type { RuntimeContext } from "../../runtimeContext.js";
 import type { CoreProviderId } from "../registry.js";
+import { createApiAdapter } from "./api.js";
+import { createGrokApiAdapter } from "./grok-api.js";
+import { createGeminiApiAdapter } from "./gemini-api.js";
 import { createAtlasCloudAdapter } from "./atlascloud.js";
 import { createComfyAdapter } from "./comfy.js";
 import { createMinimaxAdapter } from "./minimax.js";
@@ -16,6 +17,9 @@ import type { ProviderAdapterV1 } from "./types.js";
 type AdapterFactory = (ctx: RuntimeContext) => ProviderAdapterV1;
 
 const ADAPTER_FACTORIES: Partial<Record<CoreProviderId, AdapterFactory>> = {
+  api: createApiAdapter,
+  "grok-api": createGrokApiAdapter,
+  "gemini-api": createGeminiApiAdapter,
   minimax: createMinimaxAdapter,
   atlascloud: createAtlasCloudAdapter,
   comfy: createComfyAdapter,

--- a/lib/providers/adapters/minimax.ts
+++ b/lib/providers/adapters/minimax.ts
@@ -1,15 +1,13 @@
 /**
- * MiniMax adapter (#150, phase 1 reference implementation).
- *
- * MiniMax was chosen because it has the smallest runtime surface of the eight
- * lanes: one API key, two image models, no video, one reference image. That
- * makes it the cheapest place to find out whether the interface is shaped
- * correctly before the other seven follow.
- *
- * This wraps the existing runtime; it does not move it. lib/minimaxImageAdapter
- * keeps generating images exactly as before.
+ * MiniMax adapter: readiness, registry models, errors and image execution surfaces.
+ * The existing image adapter retains transport and provider protocol ownership.
  */
-import type { RuntimeContext } from "../../runtimeContext.js";
+import { generateViaMinimax } from "../../minimaxImageAdapter.js";
+import type {
+  ExecutionProgress, ExecutionSurface, ImageExecutionRequest, PreparedImageExecution,
+} from "../execution/types.js";
+import { detectImageMimeFromB64 } from "../../refs.js";
+import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
 import { getProvider } from "../registry.js";
 import type { CoreProviderModel } from "../types.js";
 import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
@@ -45,6 +43,7 @@ function readCode(error: unknown): string | undefined {
 export function createMinimaxAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
   return {
     laneId: LANE_ID,
+    prepareImageExecution: prepareLaneImageExecution,
 
     validateAuth(): AuthResult {
       // Presence only. MiniMax publishes no key prefix or length rule, so a
@@ -80,4 +79,77 @@ export function createMinimaxAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
       };
     },
   };
+}
+
+function prepareClassic(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "classic" }>,
+): PreparedImageExecution<"classic"> {
+  const { prompt: generationPrompt, requestId } = request;
+  const { model: imageModel, size: effectiveSize } = request.options;
+  // Capture scalars at prepare; ctx, refs, signal and lane options stay live.
+  return { execute: async () => {
+    const value = await generateViaMinimax(generationPrompt, requireRuntimeContext(ctx), {
+      model: imageModel, size: effectiveSize, signal: request.signal,
+      requestId, references: request.references,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareNode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "node" }>,
+): PreparedImageExecution<"node"> {
+  return { execute: async () => {
+    const { sourceImage: parentB64, rawPrompt: prompt, references, requestId, signal, options } = request;
+    const { model, size } = options;
+    const value = await generateViaMinimax(parentB64 ? `Edit this image: ${prompt}` : prompt, requireRuntimeContext(ctx), {
+      model, size, signal, requestId,
+      references: parentB64
+        ? [{ b64: parentB64, declaredMime: null, detectedMime: null }, ...references]
+        : references,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareEdit(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "edit" }>,
+): PreparedImageExecution<"edit"> {
+  return { execute: async () => {
+    const { prompt, sourceImage, signal, requestId, options } = request;
+    const references = [{ b64: sourceImage, declaredMime: null, detectedMime: detectImageMimeFromB64(sourceImage) || null }];
+    const editPrompt = `Edit this image: ${prompt}`;
+    const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
+    const value = await generateViaMinimax(editPrompt, ctx, params);
+    return { kind: "single", value };
+  } };
+}
+
+function prepareMultimode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "multimode" }>,
+): PreparedImageExecution<"multimode"> {
+  return { execute: async () => {
+    const { rawPrompt, references, signal, requestId, options } = request;
+    const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
+    const result = await generateViaMinimax(rawPrompt, ctx, params);
+    // Preserve the projection; the caller owns the final persistence sweep.
+    return { kind: "sequence", value: {
+      images: [{ b64: result.b64, ...(result.revisedPrompt !== undefined ? { revisedPrompt: result.revisedPrompt } : {}) }],
+      usage: result.usage, webSearchCalls: result.webSearchCalls,
+    } };
+  } };
+}
+
+function prepareLaneImageExecution<R extends ImageExecutionRequest>(
+  ctx: RuntimeContext, request: R, progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<R["surface"]>>;
+async function prepareLaneImageExecution(
+  ctx: RuntimeContext, request: ImageExecutionRequest, _progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<ExecutionSurface>> {
+  switch (request.surface) {
+    case "classic": return prepareClassic(ctx, request);
+    case "node": return prepareNode(ctx, request);
+    case "edit": return prepareEdit(ctx, request);
+    case "multimode": return prepareMultimode(ctx, request);
+  }
 }

--- a/lib/providers/adapters/nai.ts
+++ b/lib/providers/adapters/nai.ts
@@ -1,11 +1,12 @@
 /**
- * NovelAI adapter — lane descriptor for ProviderAdapterV1.
- *
- * Mirrors the MiniMax split: this file owns auth state, the model list, and
- * error normalization, while the generation call itself stays in
- * lib/naiImageAdapter.ts.
+ * NovelAI adapter: readiness, registry models, errors and image execution surfaces.
+ * The existing image adapter retains transport and provider protocol ownership.
  */
-import type { RuntimeContext } from "../../runtimeContext.js";
+import { generateViaNai } from "../../naiImageAdapter.js";
+import type {
+  ExecutionProgress, ExecutionSurface, ImageExecutionRequest, PreparedImageExecution,
+} from "../execution/types.js";
+import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
 import { getProvider } from "../registry.js";
 import type { CoreProviderModel } from "../types.js";
 import type { AuthResult, ProviderAdapterV1, ProviderError } from "./types.js";
@@ -38,6 +39,7 @@ function readCode(error: unknown): string | undefined {
 export function createNaiAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
   return {
     laneId: LANE_ID,
+    prepareImageExecution: prepareLaneImageExecution,
 
     validateAuth(): AuthResult {
       // Presence only. NovelAI accepts a persistent token or a session JWT and
@@ -73,4 +75,67 @@ export function createNaiAdapter(ctx: RuntimeContext): ProviderAdapterV1 {
       };
     },
   };
+}
+
+function prepareClassic(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "classic" }>,
+): PreparedImageExecution<"classic"> {
+  const { prompt: generationPrompt, requestId } = request;
+  const { model: imageModel, size: effectiveSize } = request.options;
+  // Capture scalars at prepare; ctx, refs, signal and lane options stay live.
+  return { execute: async () => {
+    // Text-to-image only: the caller already refused references.
+    const value = await generateViaNai(generationPrompt, requireRuntimeContext(ctx), {
+      model: imageModel, size: effectiveSize, signal: request.signal, requestId,
+      // Reuse the same normalized options as node and multimode.
+      ...request.nai,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareNode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "node" }>,
+): PreparedImageExecution<"node"> {
+  return { execute: async () => {
+    const { rawPrompt: prompt, requestId, signal, options } = request;
+    const { model, size } = options;
+    const value = await generateViaNai(prompt, requireRuntimeContext(ctx), {
+      model, size, signal, requestId, ...request.nai,
+    });
+    return { kind: "single", value };
+  } };
+}
+
+function prepareMultimode(
+  ctx: RuntimeContext, request: Extract<ImageExecutionRequest, { surface: "multimode" }>,
+): PreparedImageExecution<"multimode"> {
+  return { execute: async () => {
+    const { rawPrompt, signal, requestId, options } = request;
+    // Text-to-image only: admission rejects references before startJob.
+    const result = await generateViaNai(rawPrompt, ctx, {
+      model: options.model, size: options.size, signal, requestId, ...request.nai,
+    });
+    // Preserve the projection; the caller owns the final persistence sweep.
+    return { kind: "sequence", value: {
+      images: [{ b64: result.b64, ...(result.revisedPrompt !== undefined ? { revisedPrompt: result.revisedPrompt } : {}) }],
+      usage: result.usage, webSearchCalls: result.webSearchCalls,
+    } };
+  } };
+}
+
+function prepareLaneImageExecution<R extends ImageExecutionRequest>(
+  ctx: RuntimeContext, request: R, progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<R["surface"]>>;
+async function prepareLaneImageExecution(
+  ctx: RuntimeContext, request: ImageExecutionRequest, _progress?: ExecutionProgress,
+): Promise<PreparedImageExecution<ExecutionSurface>> {
+  switch (request.surface) {
+    case "classic": return prepareClassic(ctx, request);
+    case "node": return prepareNode(ctx, request);
+    case "edit": return { execute: async () => {
+      throw new Error(`Unsupported legacy edit provider: ${request.provider}`);
+    } };
+    case "multimode": return prepareMultimode(ctx, request);
+  }
 }

--- a/lib/providers/adapters/types.ts
+++ b/lib/providers/adapters/types.ts
@@ -8,10 +8,11 @@
  *
  * This is the boundary that fixes that, starting with the parts a lane already
  * owns today: authentication state, its model list, and its own error
- * vocabulary. Generation and editing stay optional here because their signature
- * depends on the cancel/retry/resume contract that #151 has not fixed yet -
- * pinning them now would mean changing them twice.
+ * vocabulary. The optional preparation hook binds a typed execution surface;
+ * callers keep cancellation, retry, and persistence lifecycle ownership.
  */
+import type { RuntimeContext } from "../../runtimeContext.js";
+import type { ExecutionProgress, ImageExecutionRequest, PreparedImageExecution } from "../execution/types.js";
 import type { JobHandle } from "../../jobs/envelope.js";
 import type { CoreProviderId } from "../registry.js";
 import type { CoreProviderModel } from "../types.js";
@@ -44,6 +45,9 @@ export interface ProviderAdapterV1 {
   /** Derived from the registry, never hand-written. */
   listModels(): readonly CoreProviderModel[];
   normalizeError(error: unknown): ProviderError;
+  prepareImageExecution?<R extends ImageExecutionRequest>(
+    ctx: RuntimeContext, request: R, progress?: ExecutionProgress,
+  ): Promise<PreparedImageExecution<R["surface"]>>;
   generateImage?(input: unknown): Promise<JobHandle>;
   editImage?(input: unknown): Promise<JobHandle>;
 }

--- a/lib/providers/execution/index.ts
+++ b/lib/providers/execution/index.ts
@@ -1,4 +1,5 @@
 import type { RuntimeContext } from "../../runtimeContext.js";
+import { getProviderAdapter } from "../adapters/index.js";
 import { assertDirectGrokKey } from "./admission.js";
 import { isLegacyExecutionRequest, prepareLegacyImageExecution } from "./legacy.js";
 import { isOpenaiRequest, prepareOpenaiExecution } from "../adapters/openaiExecution.js";
@@ -13,6 +14,8 @@ function prepareSelected(ctx: RuntimeContext, request: ImageExecutionRequest,
   if (isOpenaiRequest(request)) return prepareOpenaiExecution(ctx, request, progress);
   if (isGrokRequest(request)) return prepareGrokExecution(ctx, request, progress);
   if (isGoogleRequest(request)) return prepareGoogleExecution(ctx, request, progress);
+  const adapter = getProviderAdapter(ctx, request.provider);
+  if (adapter?.prepareImageExecution) return adapter.prepareImageExecution(ctx, request, progress);
   if (isLegacyExecutionRequest(request)) return prepareLegacyImageExecution(ctx, request, progress);
   throw new Error("Unreachable image execution provider");
 }

--- a/lib/providers/execution/legacyClassic.ts
+++ b/lib/providers/execution/legacyClassic.ts
@@ -1,66 +1,14 @@
-import { generateViaAtlasCloud } from "../../atlasCloudImageAdapter.js";
-import { generateViaMinimax } from "../../minimaxImageAdapter.js";
-import { generateViaNai } from "../../naiImageAdapter.js";
-import { generateViaComfy } from "../../comfyImageAdapter.js";
-import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
-import type { ImageBackgroundParams } from "../../imageBackgroundParam.js";
-import type {
-  ExecutionProgress, PreparedImageExecution, SingleImageExecutionResult,
-} from "./types.js";
+import type { RuntimeContext } from "../../runtimeContext.js";
+import type { ExecutionProgress, PreparedImageExecution } from "./types.js";
 import type { LegacyExecutionRequest } from "./legacy.js";
 
 type ClassicRequest = Extract<LegacyExecutionRequest, { surface: "classic" }>;
 
-function captureClassicRequest(request: ClassicRequest) {
-  const { provider: activeProvider, prompt: generationPrompt, requestId, background: backgroundParams } = request;
-  const { model: imageModel, quality, size: effectiveSize } = request.options;
-  return { activeProvider, generationPrompt, requestId, backgroundParams, imageModel, quality, effectiveSize };
-}
-
-async function executeLegacyClassic(
-  ctx: RuntimeContext, request: ClassicRequest, progress: ExecutionProgress,
-  captured: ReturnType<typeof captureClassicRequest>,
-): Promise<SingleImageExecutionResult> {
-  const { activeProvider, generationPrompt, requestId, backgroundParams, imageModel, quality, effectiveSize } = captured;
-  if (activeProvider === "atlascloud") {
-    return await generateViaAtlasCloud(generationPrompt, requireRuntimeContext(ctx), {
-      model: imageModel, size: effectiveSize, quality, signal: request.signal,
-      requestId, references: request.references,
-      ...(backgroundParams ? { background: backgroundParams.background } : {}),
-      // The caller's resolveImageBackgroundParams validates this alpha-only format.
-      ...(backgroundParams?.outputFormat ? { outputFormat: backgroundParams.outputFormat as ImageBackgroundParams["outputFormat"] } : {}),
-    });
-  }
-  if (activeProvider === "minimax") {
-    return await generateViaMinimax(generationPrompt, requireRuntimeContext(ctx), {
-      model: imageModel, size: effectiveSize, signal: request.signal,
-      requestId, references: request.references,
-    });
-  }
-  if (activeProvider === "nai") {
-    // Text-to-image only: the caller already refused references.
-    return await generateViaNai(generationPrompt, requireRuntimeContext(ctx), {
-      model: imageModel, size: effectiveSize, signal: request.signal, requestId,
-      // Reuse the same normalized options as node and multimode.
-      ...request.nai,
-    });
-  }
-  if (activeProvider === "comfy") {
-    return await generateViaComfy(generationPrompt, requireRuntimeContext(ctx), {
-      model: imageModel, size: effectiveSize, signal: request.signal,
-      requestId, references: request.references,
-      ...request.comfy, onQueue: progress.onQueue,
-    });
-  }
-  throw new Error(`Unsupported classic execution provider: ${activeProvider}`);
-}
-
 export async function prepareLegacyClassic(
-  ctx: RuntimeContext, request: ClassicRequest, progress: ExecutionProgress = {},
+  _ctx: RuntimeContext, request: ClassicRequest, _progress?: ExecutionProgress,
 ): Promise<PreparedImageExecution<"classic">> {
-  // Preserve scalar/background capture; ctx, refs, signal and lane options stay live.
-  const captured = captureClassicRequest(request);
+  const { provider } = request;
   return { execute: async () => {
-    return { kind: "single", value: await executeLegacyClassic(ctx, request, progress, captured) };
+    throw new Error(`Unsupported classic execution provider: ${provider}`);
   } };
 }

--- a/lib/providers/execution/legacyEdit.ts
+++ b/lib/providers/execution/legacyEdit.ts
@@ -1,35 +1,13 @@
 import type { RuntimeContext } from "../../runtimeContext.js";
-import { detectImageMimeFromB64 } from "../../refs.js";
-import { generateViaAtlasCloud } from "../../atlasCloudImageAdapter.js";
-import { generateViaMinimax } from "../../minimaxImageAdapter.js";
-import { generateViaComfy } from "../../comfyImageAdapter.js";
-import type { ExecutionProgress, PreparedImageExecution, SingleImageExecutionResult } from "./types.js";
+import type { ExecutionProgress, PreparedImageExecution } from "./types.js";
 import type { LegacyExecutionRequest } from "./legacy.js";
 
 type EditRequest = Extract<LegacyExecutionRequest, { surface: "edit" }>;
 
-function executeImageToImage(ctx: RuntimeContext, request: EditRequest) {
-  const { provider, prompt, sourceImage, signal, requestId, options } = request;
-  const references = [{ b64: sourceImage, declaredMime: null, detectedMime: detectImageMimeFromB64(sourceImage) || null }];
-  const editPrompt = `Edit this image: ${prompt}`;
-  const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
-  switch (provider) {
-    case "atlascloud": return generateViaAtlasCloud(editPrompt, ctx, { ...params, quality: options.quality });
-    case "minimax": return generateViaMinimax(editPrompt, ctx, params);
-    // LoadImage binding owns i2i; missing workflow binding still refuses there.
-    case "comfy": return generateViaComfy(editPrompt, ctx, params);
-    default: throw new Error(`Unsupported legacy edit provider: ${provider}`);
-  }
-}
-
-async function executeEdit(ctx: RuntimeContext, request: EditRequest): Promise<SingleImageExecutionResult> {
-  return executeImageToImage(ctx, request);
-}
-
 export async function prepareLegacyEdit(
-  ctx: RuntimeContext, request: EditRequest, _progress?: ExecutionProgress,
+  _ctx: RuntimeContext, request: EditRequest, _progress?: ExecutionProgress,
 ): Promise<PreparedImageExecution<"edit">> {
   return { execute: async () => {
-    return { kind: "single", value: await executeEdit(ctx, request) };
+    throw new Error(`Unsupported legacy edit provider: ${request.provider}`);
   } };
 }

--- a/lib/providers/execution/legacyMultimode.ts
+++ b/lib/providers/execution/legacyMultimode.ts
@@ -1,41 +1,13 @@
 import type { RuntimeContext } from "../../runtimeContext.js";
-import { generateViaAtlasCloud } from "../../atlasCloudImageAdapter.js";
-import { generateViaMinimax } from "../../minimaxImageAdapter.js";
-import { generateViaNai } from "../../naiImageAdapter.js";
-import type { ExecutionProgress, PreparedImageExecution, SequenceImageExecutionResult } from "./types.js";
+import type { ExecutionProgress, PreparedImageExecution } from "./types.js";
 import type { LegacyExecutionRequest } from "./legacy.js";
 
 type MultimodeRequest = Extract<LegacyExecutionRequest, { surface: "multimode" }>;
 
-function executeSingleLane(ctx: RuntimeContext, request: MultimodeRequest) {
-  const { provider, rawPrompt, references, signal, requestId, options } = request;
-  const params = { model: options.model, size: options.size, signal, ...(requestId !== undefined ? { requestId } : {}), references };
-  switch (provider) {
-    case "atlascloud": return generateViaAtlasCloud(rawPrompt, ctx, { ...params, quality: options.quality });
-    case "minimax": return generateViaMinimax(rawPrompt, ctx, params);
-    // Text-to-image only: no references; admission rejects them before startJob.
-    case "nai": return generateViaNai(rawPrompt, ctx, {
-      model: options.model, size: options.size, signal, requestId, ...request.nai,
-    });
-    default: throw new Error(`Unsupported legacy multimode provider: ${provider}`);
-  }
-}
-
-async function executeSequence(
-  ctx: RuntimeContext, request: MultimodeRequest, _progress: ExecutionProgress,
-): Promise<SequenceImageExecutionResult> {
-  const result = await executeSingleLane(ctx, request);
-  // Preserve the old per-lane projection: downstream detects bytes, not MIME here.
-  return {
-    images: [{ b64: result.b64, ...(result.revisedPrompt !== undefined ? { revisedPrompt: result.revisedPrompt } : {}) }],
-    usage: result.usage, webSearchCalls: result.webSearchCalls,
-  };
-}
-
 export async function prepareLegacyMultimode(
-  ctx: RuntimeContext, request: MultimodeRequest, progress: ExecutionProgress = {},
+  _ctx: RuntimeContext, request: MultimodeRequest, _progress?: ExecutionProgress,
 ): Promise<PreparedImageExecution<"multimode">> {
   return { execute: async () => {
-    return { kind: "sequence", value: await executeSequence(ctx, request, progress) };
+    throw new Error(`Unsupported legacy multimode provider: ${request.provider}`);
   } };
 }

--- a/lib/providers/execution/legacyNode.ts
+++ b/lib/providers/execution/legacyNode.ts
@@ -1,48 +1,13 @@
-import { generateViaAtlasCloud } from "../../atlasCloudImageAdapter.js";
-import { generateViaMinimax } from "../../minimaxImageAdapter.js";
-import { generateViaNai } from "../../naiImageAdapter.js";
-import { requireRuntimeContext, type RuntimeContext } from "../../runtimeContext.js";
-import type { ExecutionProgress, PreparedImageExecution, SingleImageExecutionResult } from "./types.js";
+import type { RuntimeContext } from "../../runtimeContext.js";
+import type { ExecutionProgress, PreparedImageExecution } from "./types.js";
 import type { LegacyExecutionRequest } from "./legacy.js";
 
 type NodeRequest = Extract<LegacyExecutionRequest, { surface: "node" }>;
 
 export async function prepareLegacyNode(
-  ctx: RuntimeContext, request: NodeRequest, _progress?: ExecutionProgress,
+  _ctx: RuntimeContext, request: NodeRequest, _progress?: ExecutionProgress,
 ): Promise<PreparedImageExecution<"node">> {
   return { execute: async () => {
-    return { kind: "single", value: await executeNodeAttempt(ctx, request) };
+    throw new Error(`Unsupported node execution provider: ${request.provider}`);
   } };
-}
-
-// Keep the legacy one-attempt branches together; retry/lifecycle stays at the caller.
-async function executeNodeAttempt(
-  ctx: RuntimeContext, request: NodeRequest,
-): Promise<SingleImageExecutionResult> {
-  const { provider, sourceImage: parentB64, rawPrompt: prompt,
-    references, requestId, signal, options } = request;
-  const { model, size, quality } = options;
-  return provider === "atlascloud"
-    ? await generateViaAtlasCloud(parentB64 ? `Edit this image: ${prompt}` : prompt, requireRuntimeContext(ctx), {
-        model, size, quality, signal, requestId,
-        references: parentB64
-          ? [{ b64: parentB64, declaredMime: null, detectedMime: null }, ...references]
-          : references,
-      })
-    : provider === "minimax"
-    ? await generateViaMinimax(parentB64 ? `Edit this image: ${prompt}` : prompt, requireRuntimeContext(ctx), {
-        model, size, signal, requestId,
-        references: parentB64
-          ? [{ b64: parentB64, declaredMime: null, detectedMime: null }, ...references]
-          : references,
-      })
-    : provider === "nai"
-    ? await generateViaNai(prompt, requireRuntimeContext(ctx), {
-        model, size, signal, requestId, ...request.nai,
-      })
-    : unsupportedNodeProvider(provider);
-}
-
-function unsupportedNodeProvider(provider: NodeRequest["provider"]): never {
-  throw new Error(`Unsupported node execution provider: ${provider}`);
 }

--- a/structure/01-file-function-map.md
+++ b/structure/01-file-function-map.md
@@ -231,19 +231,19 @@ scope/revision/identity reconciliation shared by polling and reload actions.
 | `lib/naiImageAdapter.ts` | 255 | NovelAI image-generation provider adapter: request build, V5 parameter gating, ZIP-to-PNG handoff, and 15 `NAI_*` operational error codes |
 | `lib/naiOptions.ts` | 145 | NovelAI request-option normalizer shared by every request-driven dispatch, plus negative-prompt history provenance |
 | `lib/naiZip.ts` | 153 | Minimal ZIP reader for NovelAI responses: stored/deflate entries, ZIP64 and encryption refusal, 50MB entry cap |
-| `lib/providers/adapters/nai.ts` | 77 | NovelAI provider-registry adapter binding: capability declaration and `normalizeError` mapping |
+| `lib/providers/adapters/nai.ts` | 142 | NovelAI provider-registry adapter binding: capability declaration and `normalizeError` mapping |
 | `lib/providers/registry.ts` | 280 | Provider lane manifests: the single declaration every generated catalog, capability list, and CLI enum derives from |
 | `lib/providers/types.ts` | 87 | Manifest/credential types, explicit model generation support, and provider surface records |
 | `lib/providers/derive.ts` | 97 | Registry-bound provider IDs, catalogs, reference limits and surface support |
 | `lib/providers/surfaceSupport.ts` | 31 | Pure application-surface projection, independent of readiness; static versus runtime catalogs |
 | `lib/providers/execution/types.ts` | 102 | Typed surface-discriminated requests, native single/sequence results and callbacks |
 | `lib/providers/execution/admission.ts` | 38 | Missing direct-Grok key and unsupported NAI multimode-ref checks; no provider probing |
-| `lib/providers/execution/index.ts` | 33 | Public prepare/execute facade with current direct-key presence checks |
+| `lib/providers/execution/index.ts` | 36 | Public prepare/execute facade with current direct-key presence checks |
 | `lib/providers/execution/legacy.ts` | 31 | Four-surface Atlas/MiniMax/NAI/Comfy dispatcher; OpenAI/Grok/Google excluded |
-| `lib/providers/execution/legacyClassic.ts` | 67 | Remaining-provider classic dispatch with preserved prepare-time capture |
-| `lib/providers/execution/legacyNode.ts` | 49 | One node transport attempt; caller owns retry, partials and persistence |
-| `lib/providers/execution/legacyEdit.ts` | 36 | Remaining-provider single edit dispatch and native result metadata |
-| `lib/providers/execution/legacyMultimode.ts` | 42 | Native sequence dispatch and existing one-image projections |
+| `lib/providers/execution/legacyClassic.ts` | 15 | Remaining-provider classic dispatch with preserved prepare-time capture |
+| `lib/providers/execution/legacyNode.ts` | 14 | One node transport attempt; caller owns retry, partials and persistence |
+| `lib/providers/execution/legacyEdit.ts` | 14 | Remaining-provider single edit dispatch and native result metadata |
+| `lib/providers/execution/legacyMultimode.ts` | 14 | Native sequence dispatch and existing one-image projections |
 | `lib/pngInfo.ts` | 27 | PNG IHDR parsing (dimensions, bit depth, colour type / alpha detection). Despite the name it reads NO text chunks — `lib/comfyPngWorkflow.ts` owns those. |
 | `lib/comfyWorkflowStore.ts` | 252 | Comfy lane model registry: per-record origin and image/video kind, legacy image normalization, id/kind validation, corrupt-file tolerance |
 | `lib/comfyGraphBind.ts` | 273 | API-format graph parsing, grouped SDXL/H3 binding inference, SaveImage/SaveVideo kind inference, non-mutating value injection, parameter derivation |

--- a/tests/_executionImportEdges.mjs
+++ b/tests/_executionImportEdges.mjs
@@ -36,6 +36,10 @@ const googleEdges = new Map([
   ["lib/agyProcess", []],
 ]);
 const googleOwners = new Set(googleEdges.keys());
+const adapterExecutionOwners = new Set([
+  "lib/providers/adapters/nai", "lib/providers/adapters/minimax",
+  "lib/providers/adapters/atlascloud", "lib/providers/adapters/comfy",
+]);
 const isLegacyOwner = (target) => /^lib\/providers\/execution\/legacy[^/]*$/.test(target);
 
 export function normalizeModulePath(file, specifier) {
@@ -150,7 +154,12 @@ export function forbiddenExecutionEdges(source, file) {
   return collectRuntimeEdges(source, file).filter(({ target }) => {
     if (EXECUTION_CALLERS.includes(file)) {
       return concreteOwners.has(target) || openaiOwners.has(target) || grokOwners.has(target)
-        || googleOwners.has(target) || isLegacyOwner(target);
+        || googleOwners.has(target) || isLegacyOwner(target) || adapterExecutionOwners.has(target);
+    }
+    if (adapterExecutionOwners.has(owner)) {
+      return target === facadeOwner || target === publicOwner || isLegacyOwner(target)
+        || openaiOwners.has(target) || grokOwners.has(target) || googleOwners.has(target)
+        || target.startsWith("routes/");
     }
     if (isLegacyOwner(owner)) return target === facadeOwner || openaiOwners.has(target)
       || grokFacades.has(target) || grokOwners.has(target) || googleFacades.has(target) || googleOwners.has(target);

--- a/tests/nai-routing-contract.test.ts
+++ b/tests/nai-routing-contract.test.ts
@@ -92,13 +92,15 @@ test("no nai dispatch forwards references to the adapter", () => {
   // generateViaNai has no references parameter. A copied MiniMax branch would
   // either fail typecheck or, behind a cast, drop the user's image silently.
   for (const file of [
-    "lib/providers/execution/legacyClassic.ts",
-    "lib/providers/execution/legacyMultimode.ts",
-    "lib/providers/execution/legacyNode.ts",
+    "lib/providers/adapters/nai.ts",
     "lib/agentImageVideoGen.ts",
   ]) {
     const calls = collectCallArguments(read(file), file, "generateViaNai");
-    assert.equal(calls.length, 1, `${file}: expected one actual NAI dispatch`);
+    if (file === "lib/providers/adapters/nai.ts") {
+      assert.ok(calls.length >= 3, `${file}: expected classic, node and multimode NAI dispatches`);
+    } else {
+      assert.equal(calls.length, 1, `${file}: expected one actual NAI dispatch`);
+    }
     for (const args of calls) {
       assert.equal(args.length, 3, `${file}: NAI options must be the third argument`);
       const options = args[2];

--- a/tests/node-studio-ui-contract.test.js
+++ b/tests/node-studio-ui-contract.test.js
@@ -279,14 +279,18 @@ describe("EN — element node lifecycle", () => {
     assert.equal(prepared.length, 1);
     assert.match(prepared[0][1], /prompt: generationPrompt/);
     assert.match(prepared[0][1], /rawPrompt: prompt/);
-    const owner = "lib/providers/execution/legacyNode.ts";
-    const execution = read(owner);
     const openaiOwner = "lib/providers/adapters/openaiExecution.ts";
     const openaiExecution = read(openaiOwner);
     const grokOwner = "lib/providers/adapters/grokExecution.ts";
     const grokExecution = read(grokOwner);
     const googleOwner = "lib/providers/adapters/googleExecution.ts";
     const googleExecution = read(googleOwner);
+    // Legacy lanes now own their node dispatch inside their adapter's prepareNode.
+    const adapterOwners = {
+      generateViaAtlasCloud: "lib/providers/adapters/atlascloud.ts",
+      generateViaMinimax: "lib/providers/adapters/minimax.ts",
+      generateViaNai: "lib/providers/adapters/nai.ts",
+    };
     for (const [name, position, expected] of [
       ["generateViaResponses", 1, "generationPrompt"],
       ["editViaResponses", 1, "generationPrompt"],
@@ -303,7 +307,7 @@ describe("EN — element node lifecycle", () => {
         ? collectCallArguments(grokExecution, grokOwner, name, "executeGrokNode")
         : name === "generateViaGeminiApi" || name === "generateViaAgy"
         ? collectCallArguments(googleExecution, googleOwner, name, "runGoogleImage")
-        : collectCallArguments(execution, owner, name);
+        : collectCallArguments(read(adapterOwners[name]), adapterOwners[name], name, "prepareNode");
       assert.equal(calls.length, 1, `${name}: expected a live call expression`);
       assert.equal(calls[0][position], expected, `${name}: wrong prompt lane`);
     }

--- a/tests/provider-adapter-v1-contract.test.ts
+++ b/tests/provider-adapter-v1-contract.test.ts
@@ -40,6 +40,9 @@ function contextWith(key: string | undefined): RuntimeContext {
   // as the keys. That state must arrive through RuntimeContext — a module-level
   // store cache could not be empty and non-empty for the two calls below.
   return {
+    apiKey: key,
+    xaiApiKey: key,
+    geminiApiKey: key,
     minimaxApiKey: key,
     atlasCloudApiKey: key,
     naiApiKey: key,
@@ -56,6 +59,9 @@ const withoutKey = contextWith(undefined);
  * for every lane the suite iterates.
  */
 const EXPECTED_AUTH_REASON: Record<string, RegExp> = {
+  api: /OpenAI API key missing/,
+  "grok-api": /xAI API key missing/,
+  "gemini-api": /Gemini API key or Vertex service account missing/,
   minimax: /MiniMax API key missing/,
   atlascloud: /Atlas Cloud API key missing/,
   comfy: /workflow/i,
@@ -186,7 +192,41 @@ test("an existing provider-specific code is preserved, not double-prefixed", () 
 });
 
 test("an unregistered lane returns null so its current path is untouched", () => {
-  for (const lane of ["oauth", "api", "grok", "grok-api", "agy", "gemini-api"] as const) {
-    assert.equal(getProviderAdapter(withKey, lane), null, `${lane} must not be adapter-routed yet`);
+  // OAuth proxy readiness, Grok health and Antigravity binary detection are async.
+  for (const lane of ["oauth", "grok", "agy"] as const) {
+    assert.equal(getProviderAdapter(withKey, lane), null, `${lane} needs async readiness before descriptor registration`);
   }
+});
+
+for (const { name, credentials, expected } of [
+  { name: "key-only credentials", credentials: { geminiApiKey: "key" }, expected: { ok: true } },
+  { name: "Vertex-only credentials", credentials: { vertexServiceAccountJson: "{}" }, expected: { ok: true } },
+  { name: "both credentials", credentials: { geminiApiKey: "key", vertexServiceAccountJson: "{}" }, expected: { ok: true } },
+  { name: "neither credential", credentials: {}, expected: { ok: false, reason: "Gemini API key or Vertex service account missing" } },
+]) {
+  test(`gemini-api ${expected.ok ? "accepts" : "rejects"} ${name}`, () => {
+    const ctx = { ...withoutKey, ...credentials } as RuntimeContext;
+    assert.deepEqual(getProviderAdapter(ctx, "gemini-api")?.validateAuth(), expected);
+  });
+}
+
+test("legacy lanes own their execution", () => {
+  for (const lane of ["nai", "minimax", "atlascloud", "comfy"] as const) {
+    assert.equal(typeof getProviderAdapter(withKey, lane)?.prepareImageExecution, "function", lane);
+  }
+  for (const lane of ["api", "grok-api", "gemini-api"] as const) {
+    const adapter = getProviderAdapter(withKey, lane);
+    assert.ok(adapter, `${lane} descriptor must be registered`);
+    assert.equal(adapter.prepareImageExecution, undefined, lane);
+  }
+});
+
+test("api normalizes errors without a provider prefix", () => {
+  const adapter = getProviderAdapter(withKey, "api")!;
+  assert.deepEqual(adapter.normalizeError(Object.assign(new Error("busy"), { code: "rate_limit", statusCode: 429 })), {
+    code: "rate_limit", message: "busy", status: 429, retryable: true,
+  });
+  assert.deepEqual(adapter.normalizeError("unknown failure"), {
+    code: "UNKNOWN", message: "unknown failure", retryable: false,
+  });
 });

--- a/tests/provider-execution-imports.test.ts
+++ b/tests/provider-execution-imports.test.ts
@@ -53,6 +53,7 @@ test("every concrete owner and private legacy module is forbidden for every call
     "grokImagePlanner", "grokImageDownload", "grokImageDownloadPolicy",
     "providers/adapters/googleExecution", "providers/adapters/agyOperations", "providers/adapters/geminiOperations",
     "agyProcess", "agyArtifact",
+    "providers/adapters/nai", "providers/adapters/minimax", "providers/adapters/atlascloud", "providers/adapters/comfy",
   ];
   for (const file of EXECUTION_CALLERS) for (const name of owners) for (const ext of ["js", "ts"]) {
     const prefix = file.startsWith("routes/") ? "../lib/" : "./";
@@ -94,8 +95,13 @@ const googleOwners = [
   "lib/providers/adapters/geminiOperations.ts", "lib/agyProcess.ts", "lib/agyArtifact.ts",
 ];
 
-test("actual internal OpenAI, Grok, Google and legacy owners contain no forbidden runtime edges", () => {
-  for (const file of [...legacyOwners, ...openaiOwners, ...grokOwners, ...googleOwners]) {
+const adapterExecutionOwners = [
+  "lib/providers/adapters/nai.ts", "lib/providers/adapters/minimax.ts",
+  "lib/providers/adapters/atlascloud.ts", "lib/providers/adapters/comfy.ts",
+];
+
+test("actual internal family, adapter and legacy owners contain no forbidden runtime edges", () => {
+  for (const file of [...legacyOwners, ...openaiOwners, ...grokOwners, ...googleOwners, ...adapterExecutionOwners]) {
     const source = readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
     assert.deepEqual(forbiddenExecutionEdges(source, file), [], file);
   }
@@ -306,5 +312,38 @@ test("in-memory caller mutations cannot pass by retaining imports or comments", 
     const withoutPublicBinding = source.replace(/\bprepareImageExecution\b/g, "unrelatedPrepare");
     assert.notEqual(withoutPublicBinding, source, `${file}: prepare mutation must activate`);
     assert.equal(inspectExecutionCaller(withoutPublicBinding, file).prepareCalls, 0, file);
+  }
+});
+
+test("adapter execution owners reject upward, legacy and cross-family runtime edges", () => {
+  for (const file of adapterExecutionOwners) {
+    for (const target of [
+      "lib/providers/execution/index", "routes/edit", "lib/responsesImageAdapter",
+      ...legacyOwners.map((path) => path.replace(/\.ts$/, "")),
+      ...openaiOwners.map((path) => path.replace(/\.ts$/, "")),
+      ...grokOwners.map((path) => path.replace(/\.ts$/, "")),
+      ...googleOwners.map((path) => path.replace(/\.ts$/, "")),
+    ]) {
+      const specifier = `./${posix.relative(posix.dirname(file), `${target}.js`)}`;
+      for (const source of [
+        `import { run as alias } from "${specifier}";`,
+        `export * from "${specifier}";`, `const run = await import("${specifier}");`,
+      ]) {
+        const edges = forbiddenExecutionEdges(source, file);
+        assert.equal(edges.length, 1, `${file}: ${source}`);
+        assert.equal(edges[0].target, target);
+      }
+      assert.deepEqual(forbiddenExecutionEdges(`import type { Options } from "${specifier}";`, file), []);
+    }
+  }
+});
+
+test("callers cannot bypass the execution seam through lane adapters", () => {
+  for (const file of EXECUTION_CALLERS) for (const target of adapterExecutionOwners) {
+    const specifier = `./${posix.relative(posix.dirname(file), target.replace(/\.ts$/, ".js"))}`;
+    const source = `import { createNaiAdapter as bypass } from "${specifier}";`;
+    const edges = forbiddenExecutionEdges(source, file);
+    assert.equal(edges.length, 1, `${file}: ${source}`);
+    assert.equal(edges[0].target, target.replace(/\.ts$/, ""));
   }
 });


### PR DESCRIPTION
Refs #150 (Provider Adapter v1).

## Problem
Registered adapters owned auth, model lists and error vocabulary, but every legacy lane's generation was still dispatched by `lib/providers/execution/legacy*.ts` switches, so adding a provider meant editing core execution. Only 4 of 10 lanes had adapters.

## Change
- `ProviderAdapterV1.prepareImageExecution?` (type-only import from `execution/types`) and a runtime edge `execution/index.ts -> adapters/index.ts`: a registered adapter that implements the hook is used before the legacy switches.
- `nai`, `minimax`, `atlascloud`, `comfy` adapters own their classic/node/edit/multimode preparation (same call arguments, prompt lanes, prepare-time capture, sequence projection and "Unsupported …" refusal text, still raised inside `execute()`). `legacy{Classic,Node,Edit,Multimode}.ts` keep only the refusal.
- New descriptor adapters `api.ts`, `grok-api.ts`, `gemini-api.ts` (readiness = `apiKey` / `xaiApiKey` / `geminiApiKey || vertexServiceAccountJson`); `oauth`, `grok`, `agy` stay unregistered because their readiness is asynchronous (proxy state, binary detection).
- Import policy: `tests/_executionImportEdges.mjs` gains `adapterExecutionOwners` with a forbidden-edge branch and caller-bypass rule; `provider-execution-imports` adds negative mutation cases. Source-shape oracles moved with the code (`nai-routing-contract`, `node-studio-ui-contract`); contract suite covers 7 adapters with four gemini readiness fixtures.

## Measurement for #150
`listProviderAdapters` = 7 (was 4); adapters owning execution = 4; `generateVia*` calls left in `legacy*.ts` = 0; UI provider literals unchanged (10 + 1) — out of scope here.

## Validation (local, 64bc7ffe)
typecheck, typecheck:tests, test:inventory, generate-provider-types --check, server/cli/ui builds, structure line counts: exit 0. `npm test`: 3501 tests, 3498 pass, 0 fail, 3 skipped.

