### PR TITLE
docs(grok): roadmap for native xAI OAuth, replacing the progrok proxy [stack 1/5]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ cache/
 !devlog/_fin/260905_production_readiness/**
 !devlog/_plan/260908_xai_imagine_spec_resync/
 !devlog/_plan/260908_xai_imagine_spec_resync/**
+!devlog/_plan/260909_grok_native_oauth/
+!devlog/_plan/260909_grok_native_oauth/**

--- a/devlog/_plan/260909_grok_native_oauth/000_plan.md
+++ b/devlog/_plan/260909_grok_native_oauth/000_plan.md
@@ -1,0 +1,105 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, progrok, roadmap, plan]
+---
+
+# 000 — Grok 레인 네이티브 xAI OAuth 전환 계획
+
+## 결론
+
+progrok 자식 프로세스 프록시를 걷어내고, `grok` 레인이 `https://api.x.ai`를 OAuth
+access token으로 직접 부르게 한다. `grok-api`(직접 키) 레인과는 자격증명 출처만
+다른 단일 코드 경로가 된다. 프록시 슈퍼바이저(`lib/grokProxyLauncher.ts` 325줄),
+포트 협상, probe token, `waiting-for-login` 상태 기계, advertise의 `grok.live`가
+전부 사라진다. 기존 사용자의 `~/.progrok/auth.json`은 그대로 읽으므로 재로그인이
+없다.
+
+## 왜 지금인가
+
+progrok이 ima2 안에서 실제로 담당하는 일은 두 가지뿐이다. 만료 2분 전 refresh,
+그리고 `Bearer dummy`를 진짜 토큰으로 바꿔 포워딩. 로그인(device code)은
+`routes/auth.ts:79-141`이 이미 자체 구현했고, quota는 `routes/quota.ts:121`이
+`auth.json`을 직접 읽는다. 그 두 가지를 위해 325줄짜리 7상태 슈퍼바이저와 8곳의
+`provider === "grok-api" ? ctx.xaiApiKey : undefined` 분기가 존재한다
+(002_callsite_inventory.md §8). `getGrokEndpoint`(`lib/grokImageCore.ts:62`)는
+`directApiKey`가 있으면 이미 직접 `api.x.ai`를 친다. OAuth 토큰을 그 자리에 넣는
+것이 전환의 전부다.
+
+## 조사 근거 (000번대)
+
+| 문서 | 내용 | 출처 |
+|---|---|---|
+| 001_opencodex_port_spec.md | OpenCodex `src/oauth/xai.ts` 이식 사양, 결함 D1~D9, `lib/xaiAuth.ts` API 초안 | opus-5 explorer + Node 24 실측 |
+| 002_callsite_inventory.md | 프록시 도달 경로 전수(이미지/비디오/플래너/status), readiness 소비자, 401 훅 위치 | opus-5 explorer |
+| 003_removal_blast_radius.md | 삭제/수정 파일 전수, 테스트 판정, SoT/문서/site/i18n, CI 게이트 | opus-5 explorer |
+| 004_xai_docs_aside_research.md | docs.x.ai 183페이지 grep, OIDC discovery 실측, progrok 원본 | Aside exec (실브라우저) |
+
+## 확정한 결정
+
+| # | 결정 | 근거 |
+|---|---|---|
+| R1 | `grok` 레인은 폐기하지 않고 직접 호출로 재배선한다 | 003 §1-2 선택지 (b). 폐기하면 registry/UI/enum 전반 연쇄, 사용자 기능 손실 |
+| R2 | 자격증명 파일 경로·스키마는 `~/.progrok/auth.json` 그대로 유지 | 001 §3. 기존 사용자 무마이그레이션. `idToken`은 있으면 보존 |
+| R3 | `expiresAt`은 raw epoch ms, skew 120s는 읽는 쪽에서 적용 | 001 D8. OpenCodex의 skew 선차감 방식을 따르면 이중 차감 |
+| R4 | refresh 실패 시 파일을 지우지 않는다. terminal(`invalid_grant`/`refresh_token_reused`/`revoked_token`) → `GROK_AUTH_REQUIRED`, 그 외 → `GROK_AUTH_REFRESH_FAILED` | 001 §4 |
+| R5 | single-flight refresh + terminal negative cache 30s | 001 §6. 병렬 12건이 refresh_token을 12번 태우지 않게 |
+| R6 | 401 재시도는 `lib/grokUpstreamRetry.ts`(leaf)에 넣지 않고, 새 `lib/grokRuntime.ts`의 `fetchWithGrokAuth`가 헤더를 재구성해 정확히 1회 재시도 | 001 §4, 002 §5. `grokFetchWithRetry`는 헤더를 다시 만들 수 없음 |
+| R7 | `lib/atomicWrite.ts`는 재사용하지 않는다(0600 미보장, pid 고정 tmp). `routes/auth.ts:70-73` 패턴을 `lib/xaiAuth.ts`로 옮긴다 | 001 §4 |
+| R8 | `/api/grok/status` 응답 리터럴(`ready`/`no_image_model`/`error`/`offline`)은 유지하고 의미만 재매핑 | 002 §3. UI 변경 최소화 |
+| R9 | advertise payload의 `grok` 키는 `{ auth: "oauth" \| "none" }`로 축소. `~/.ima2/server.json`은 외부 계약이라 키 자체는 남긴다 | 003 §1-4 |
+| R10 | `findAvailablePort` export는 유지(테스트 2개 소비) | 003 §1-7 |
+| R11 | `ima2 grok login/status/logout`은 네이티브 서브커맨드로 재작성. `models`/`proxy`는 제거 | 003 §1-8 |
+| R12 | OpenCodex 결함 D1/D2/D3/D6은 lidge-jun/opencodex(canonical; package.json repository)에 이슈로 등록(코드 수정은 범위 밖) | 001 §5, 사용자 승인 |
+
+## 알려진 위험
+
+- **xAI가 OAuth→api.x.ai를 공식 문서화하지 않았다** (004 §0, §3). 문서상 OAuth를
+  받는다고 명시된 엔드포인트는 `/v1/me`뿐이다. progrok이 지금까지 같은 경로로
+  동작해 왔으므로 전환 자체가 위험을 새로 만들지는 않지만, 이 경로가 닫히면
+  `grok-api`(키) 레인만 남는다. 이 사실을 structure/06과 README에 명기한다(wp5).
+- access token 수명과 refresh rotation 정책이 미문서(004 §4). `expiresAt` 부재를
+  "모름"으로 다루고 401을 신호로 쓴다(R3, 001 D5).
+- pr-fast.yml에는 package install smoke와 Windows 레인이 없다(003 §5-2).
+  progrok 제거의 패키징 파손은 dev push 후 ci.yml에서야 보인다. wp4 C에서
+  `workflow_dispatch`로 ci.yml을 후보 SHA에 직접 돌린다.
+
+## 워크페이즈 지도 (의존 순)
+
+| WP | 브랜치 | PR base | 내용 | 문서 |
+|---|---|---|---|---|
+| wp1 | `codex/grok-native-oauth-01-roadmap` | dev | 이 유닛의 000~050 문서만 | 이 문서 |
+| wp2 | `codex/grok-native-oauth-02-xai-auth` | wp1 | `lib/xaiAuth.ts` + 계약 테스트. 아직 아무도 호출하지 않음 | 010 |
+| wp3 | `codex/grok-native-oauth-03-direct-lane` | wp2 | `lib/grokRuntime.ts` 재작성(`resolveGrokCredential`, `fetchWithGrokAuth`), 호출부 11곳 전환, 프록시 코드는 아직 존재하되 미사용 | 020 |
+| wp4 | `codex/grok-native-oauth-04-remove-progrok` | wp3 | 슈퍼바이저/config/vendor/CLI 제거, readiness 재정의, 테스트 삭제·재작성, 생성물 게이트 | 030 |
+| wp5 | `codex/grok-native-oauth-05-docs` | wp4 | structure SoT, README/docs/site/i18n, 선행 유닛 아카이브, 최종 CI green | 040 |
+
+050_verification.md가 각 WP의 C 게이트와 최종 증거 형식을 정의한다.
+
+각 레이어는 자기 tip에서 typecheck/test가 통과해야 한다(DEV-STACK-03). wp3 tip에서는
+프록시 코드가 남아 있지만 호출자가 없으므로 컴파일·테스트가 그대로 통과한다.
+wp2 tip에서는 `lib/xaiAuth.ts`가 고립 모듈이라 기존 동작에 영향이 없다.
+
+## 범위 밖
+
+openai-oauth 프록시 전환, 새 provider, PR #229, UI 디자인 변경, OpenCodex 코드 수정,
+`grok-api` 플래너의 xAI 경유 여부(002 §4 별건), merge/release.
+
+## SoT 동기화 대상 (wp5)
+
+`structure/00-structure-hub.md`, `structure/01-file-function-map.md`,
+`structure/02-command-reference.md`, `structure/06-infra-operations.md`,
+`AGENTS.md:28`, `README.md`, `docs/{API,CLI,README.ko}.md` + zh 번역 6종,
+`site/src/pages/docs/**` 12파일, `skills/ima2/SKILL.md:88`, `ui/src/i18n/*.json` 4로케일.
+전체 목록은 003 §3, §6.
+
+## OpenCodex 이슈
+
+canonical 저장소는 lidge-jun/opencodex(package.json `repository`). 코드 수정은 이 유닛 범위 밖.
+
+| 결함 | 이슈 | 상태 |
+|---|---|---|
+| D1 retry-after 2000ms 절삭 | lidge-jun/opencodex#4045 | 등록 (2026-09-09) |
+| D2 retry-after HTTP-date 무시 | lidge-jun/opencodex#4046 | 등록 (2026-09-09) |
+| D3 커스텀 abort reason 재시도 | lidge-jun/opencodex#4047 | 등록 (2026-09-09) |
+| D6 endpoint host 검증 (서브도메인·userinfo) | lidge-jun/opencodex#4048 | 등록 (2026-09-09) |

--- a/devlog/_plan/260909_grok_native_oauth/001_opencodex_port_spec.md
+++ b/devlog/_plan/260909_grok_native_oauth/001_opencodex_port_spec.md
@@ -1,0 +1,434 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, opencodex, port-spec, research]
+---
+
+# 001 — OpenCodex xai.ts 이식 사양과 결함 감사 (opus-5 explorer, 2026-09-09)
+
+읽기 전용 조사 결과를 그대로 보존한다. D1/D2/D3/D6은 lidge-jun/opencodex 이슈 후보이며,
+등록 여부와 번호는 000_plan.md의 "OpenCodex 이슈" 절에 기록한다.
+
+
+# xAI OAuth 클라이언트 이식 사양 (OpenCodex `src/oauth/xai.ts` → ima2-gen `lib/xaiAuth.ts`)
+
+조사 대상 커밋: ima2-gen `dev` @ `d4773557` (v3.15.1, Node `>=22`, `.node-version` 24.17.0), OpenCodex `src/oauth/xai.ts` 241줄, 번들 progrok 0.2.0 (`vendor/progrok-0.2.0.tgz`, `package.json:102`).
+
+## 1. `xai.ts` export 인벤토리와 이식 판정
+
+런타임 전제부터 정리한다. OpenCodex는 Bun 전용이다. `package.json:9` `"bun": "./src/index.ts"`, `bin/package-main.mjs`가 `if (typeof Bun === "undefined") throw new Error("The opencodex programmatic API requires the Bun runtime.")`로 Node 진입을 막는다. 반면 ima2-gen은 Node 24 ESM이다. 그래서 `Bun.sleep` 하나가 이식의 필수 교체 지점이다.
+
+| Export | 시그니처 | Bun/Node 의존 | 판정 |
+|---|---|---|---|
+| `XAI_OAUTH_DISCOVERY_URL` | `const: string` (`xai.ts:7`) | 없음 | **KEEP** — `routes/auth.ts:79` 하드코딩 URL과 동일 문자열 |
+| `XAI_OAUTH_CLIENT_ID` | `const: string` (`xai.ts:8`) | 없음 | **KEEP** — `routes/auth.ts:11` `GROK_CLIENT_ID`와 완전 동일 |
+| `XAI_OAUTH_SCOPE` | `const: string` (`xai.ts:9`) | 없음 | **KEEP** — `routes/auth.ts:12` `GROK_SCOPE`와 완전 동일 |
+| `XAI_LOCAL_CLI_DETACH_WARNING` | `const: string` (`xai.ts:15-16`) | 없음 | **DROP** — `~/.grok` 소유권 이관 경고. ima2는 `~/.grok`을 읽기 전용으로만 본다 (`routes/quota.ts:105`) |
+| `XaiTokenPayload` | `interface` (`xai.ts:28-34`) | 없음 | **KEEP** |
+| `discoverXaiOAuthEndpoints` | `(signal?: AbortSignal) => Promise<XaiDiscovery>` (`xai.ts:56`) | `fetch`, `AbortSignal.timeout`, `AbortSignal.any` — 전부 Node 18+ 표준 | **ADAPT** — `device_authorization_endpoint`도 반환하도록 확장 (`routes/auth.ts:80-81`이 필요로 함) |
+| `XaiTokenRequestError` | `class extends Error { status?: number; oauthError?: string }` (`xai.ts:95`) | 없음 | **KEEP** — `oauthError`가 `invalid_grant` 판정의 유일한 근거 |
+| `XaiTokenRetryDeps` | `interface { sleep?; random? }` (`xai.ts:96`) | 없음 | **KEEP** — 테스트 주입점 |
+| `postXaiToken` | `(tokenEndpoint, body, signal?, deps?) => Promise<XaiTokenPayload>` (`xai.ts:100-115`) | **`Bun.sleep` (`xai.ts:105`)**, `DOMException` (`xai.ts:97`) | **ADAPT** — 아래 §5 결함 수정 포함 |
+| `XaiOAuthFlow` | `class extends OAuthCallbackFlow` (`xai.ts:141`) | `callback-server.ts:63` `Bun.serve` | **DROP** |
+| `loginXai` | `(ctrl, opts?) => Promise<OAuthCredentials>` (`xai.ts:196`) | `XaiOAuthFlow` 경유 `Bun.serve` | **DROP** |
+| `refreshXaiToken` | `(refreshToken, signal?) => Promise<OAuthCredentials>` (`xai.ts:226`) | `postXaiToken` 경유 `Bun.sleep` | **KEEP (핵심)** |
+| `credentialsFromTokenPayload` (비-export) | `(payload, refreshFallback?) => OAuthCredentials` (`xai.ts:117`) | 없음 | **KEEP** — export로 승격 |
+| `decodeJwtPayload` / `getTokenIdentity` (비-export) | `xai.ts:76`, `xai.ts:87` | `Buffer.from(..., "base64url")` — Node 네이티브 | **KEEP** |
+| `validateXaiEndpoint` (비-export) | `(rawUrl: string) => string` (`xai.ts:47`) | 없음 | **ADAPT** — §5 D6 |
+
+**PKCE / callback-server DROP 확정.** 근거 셋. (1) ima2는 이미 device-code 플로우를 완성해 두었다 — `routes/auth.ts:79-141`이 discovery → `device_authorization_endpoint` POST → `urn:ietf:params:oauth:grant-type:device_code` 폴링까지 자체 구현했고, `CODEX_DEVICE_CODE_GRANT`(`routes/auth.ts:15`)를 쓴다. (2) xAI discovery가 device_code grant를 실제로 광고한다 — 라이브 확인:
+
+```json
+"grant_types_supported":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:device_code"]
+"device_authorization_endpoint":"https://auth.x.ai/oauth2/device/code"
+```
+
+(3) `XaiOAuthFlow`가 상속하는 `OAuthCallbackFlow`는 `callback-server.ts:63` `type BunServer = ReturnType<typeof Bun.serve>`에 묶여 있어 Node 이식 시 서버 계층 전체를 다시 써야 한다. 이식 대상은 **refresh 경로 하나**로 좁히는 게 맞다. `generatePKCE`(`pkce.ts:5-15`)는 순수 WebCrypto라 Node에서 돌지만, PKCE를 쓰는 authorization_code 플로우 자체가 DROP이므로 함께 뺀다.
+
+## 2. 이식할 상수와 client_id 대조
+
+```ts
+// xai.ts:6-13
+const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_OAUTH_CALLBACK_PORT = 56121;          // DROP
+const XAI_OAUTH_CALLBACK_PATH = "/callback";    // DROP
+const XAI_OAUTH_REFRESH_SKEW_MS = 2 * 60 * 1000;
+const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+```
+
+재시도 정책은 `postXaiToken`에 인라인되어 있다. 최대 3회 시도(`xai.ts:106` `attempt<=3`), 백오프 base는 1차 100ms / 그 이후 250ms에 ±25% 지터(`xai.ts:98`), 상한 2000ms, `retry-after`는 `/^\d+$/` 정수 초만 인식. 재시도 상태는 **429와 5xx만**(`xai.ts:114` `response.status===429||response.status>=500`), 네트워크 예외는 재시도하되 호출자 abort는 즉시 전파.
+
+**client_id / scope 3자 대조 — 전부 일치, 리스크 없음.**
+
+| 값 | OpenCodex | ima2 | progrok 0.2.0 |
+|---|---|---|---|
+| client_id | `b1a00492-...-4c329264a828` (`xai.ts:8`) | 동일 (`routes/auth.ts:11`) | 동일 (`dist/index.js:16`) |
+| scope | `openid profile email offline_access grok-cli:access api:access` (`xai.ts:9`) | 동일 (`routes/auth.ts:12`) | 동일 (`dist/index.js:17`) |
+| issuer | `https://auth.x.ai` (`xai.ts:6`) | 동일 (`routes/auth.ts:13` 토큰 URL) | 동일 (`dist/index.js:18`) |
+| refresh skew | 120,000ms (`xai.ts:12`) | 없음 (refresh 미구현) | 120,000ms (`dist/index.js:28`) |
+| 요청 타임아웃 | 30,000ms (`xai.ts:13`) | discovery 10s / device 15s / token 10s (`routes/auth.ts:79,87,120`) | 30,000ms (`dist/index.js:25`) |
+
+세 구현이 같은 client_id를 쓰므로, ima2 device-code로 발급한 토큰을 `lib/xaiAuth.ts`가 갱신하고 progrok이 이어 갱신해도 grant가 깨지지 않는다. 이식 시 `XAI_OAUTH_REFRESH_SKEW_MS`는 progrok의 `TOKEN_REFRESH_SKEW_MS`와 값이 같아 두 프로세스의 갱신 판단이 어긋나지 않는다 — 다만 skew 적용 **지점**이 다르다(§3, D8).
+
+`token_endpoint`는 하드코딩(`routes/auth.ts:13` `https://auth.x.ai/oauth2/token`)과 discovery 조회(`xai.ts:230`) 두 방식이 공존하는데, 라이브 discovery가 정확히 그 값을 반환하므로 현재는 동치다. 디스크에 `tokenEndpoint`가 이미 저장돼 있으니(§3) 갱신 시에는 저장값 우선, 없을 때만 discovery로 폴백하는 게 왕복을 줄인다.
+
+## 3. `~/.progrok/auth.json` 스키마 3자 대조
+
+**ima2가 쓰는 형태** (`routes/auth.ts:60-73`):
+
+```ts
+const data: Record<string, unknown> = {
+  accessToken: tokens.access_token,
+  refreshToken: tokens.refresh_token,
+  expiresAt: typeof tokens.expires_in === "number" ? Date.now() + (tokens.expires_in as number) * 1000 : undefined,
+  tokenEndpoint: GROK_TOKEN_URL,
+};
+if (email) data.email = email;
+```
+
+**progrok이 쓰는 형태** (`dist/index.js:194-214`):
+
+```js
+const data = {
+  accessToken: input.accessToken,
+  refreshToken: input.refreshToken,
+  expiresAt: input.expiresIn ? Date.now() + input.expiresIn * 1e3 : void 0,
+  tokenEndpoint: input.tokenEndpoint,
+  idToken: input.idToken
+};
+// id_token JWT payload.email → data.email
+writeFileSync(AUTH_FILE, JSON.stringify(data, null, 2), { mode: 384 });   // 384 = 0o600
+```
+
+**OpenCodex `OAuthCredentials`** (`types.ts:28-45`): `{ refresh, access, expires, email?, accountId?, source? }`. `expires`는 "epoch ms after any small provider-specific early-refresh margin" — 즉 skew가 **이미 차감된** 값(`xai.ts:135` `Date.now() + expiresIn*1000 - XAI_OAUTH_REFRESH_SKEW_MS`).
+
+현재 실제 디스크 상태(내 홈 기준 확인): `["accessToken","refreshToken","expiresAt","tokenEndpoint"]`.
+
+차이는 셋이다. ima2는 `idToken`을 저장하지 않는다(progrok은 저장). ima2는 `accountId`/`sub`를 전혀 기록하지 않는다. 그리고 결정적으로 **`expiresAt`의 의미가 다르다** — progrok/ima2는 원시 만료 시각이고 skew는 읽는 쪽에서 뺀다(`dist/index.js:235` `Date.now() + TOKEN_REFRESH_SKEW_MS >= tokens.expiresAt`), OpenCodex `expires`는 skew가 이미 반영된 값이다.
+
+**제안 스키마 — 마이그레이션 불필요, 기존 파일과 바이트 호환.**
+
+```ts
+// lib/xaiAuth.ts on-disk schema (~/.progrok/auth.json)
+interface ProgrokAuthFile {
+  accessToken: string;          // required
+  refreshToken?: string;        // absent → refresh 불가, GROK_AUTH_REQUIRED
+  expiresAt?: number;           // epoch ms, RAW (skew 미차감) — progrok 의미론 유지
+  tokenEndpoint?: string;       // 없으면 discovery 폴백
+  email?: string;               // id_token 또는 access_token JWT에서 추출
+  idToken?: string;             // progrok 호환: 있으면 보존, 없으면 새로 쓰지 않음
+  accountId?: string;           // NEW, optional. progrok/quota가 무시하므로 안전
+}
+```
+
+필드 매핑:
+
+| OAuthCredentials | ProgrokAuthFile | 변환 |
+|---|---|---|
+| `access` | `accessToken` | 그대로 |
+| `refresh` | `refreshToken` | 그대로 |
+| `expires` (skew 차감됨) | `expiresAt` (raw) | 읽기 `expires = expiresAt`, 쓰기 `expiresAt = Date.now() + expires_in*1000` |
+| `email` | `email` | 그대로 |
+| `accountId` | `accountId` | 신규 optional |
+| `source` | — | 저장 안 함. `~/.progrok`는 정의상 로컬 OAuth 소유 |
+
+호환성 근거: 추가 키를 넣어도 progrok `loadTokens()`(`dist/index.js:216-223`)는 `JSON.parse` 후 필드 접근만 하므로 무시하고, `routes/quota.ts:121-126`은 `accessToken`만 읽으며, `bin/lib/doctor-providers.ts:51`은 파일 존재 여부만 본다. **읽을 때 `idToken`이 있으면 그대로 되써야 한다** — 안 그러면 ima2의 갱신이 progrok이 저장한 `idToken`을 지운다.
+
+**skew 의미론 경계를 명시적으로 그어라.** `lib/xaiAuth.ts` 내부에서는 `expires`를 raw로 다루고, 만료 판정에서만 `Date.now() + SKEW_MS >= expiresAt`으로 비교한다(progrok과 동일). `credentialsFromTokenPayload`를 그대로 가져오면 skew가 이중 차감되어 유효 수명이 2분 더 짧아진다 — 잘못된 갱신은 아니지만 progrok과 판단이 어긋나 불필요한 갱신 경합이 생긴다.
+
+## 4. ima2 refresh 알고리즘 사양
+
+**skew.** 120초, progrok `TOKEN_REFRESH_SKEW_MS`(`dist/index.js:28`)와 동일. 판정식은 progrok과 글자 그대로 맞춘다: `expiresAt !== undefined && Date.now() + 120_000 >= expiresAt`. `expiresAt`이 없으면(device-code 응답에 `expires_in`이 없던 경우, `routes/auth.ts:63`이 `undefined`로 남김) 만료 미상 → 낙관적으로 사용하고 401을 신호로 삼는다.
+
+**single-flight.** OpenCodex는 `Map<key, flight>` + stale 회수 방식이다(`index.ts:502-541`): `tokenRefreshes.get(key)`로 기존 비행 조인, `OAUTH_TOKEN_REFRESH_FLIGHT_STALE_MS`(120초, `index.ts:114`) 초과 시 abort 후 교체, `MAX_OAUTH_TOKEN_REFRESH_FLIGHTS` 32개 상한. ima2는 계정이 하나뿐이므로 이걸 단일 모듈 변수로 줄인다:
+
+```ts
+let refreshFlight: { promise: Promise<GrokCredentials>; startedAt: number } | undefined;
+```
+
+조인 조건은 `Date.now() - startedAt <= 120_000`. `finally`에서 자기 자신일 때만 해제(`index.ts:537` `if (tokenRefreshes.get(key) === flight)` 패턴)해야 늦게 끝난 이전 비행이 새 비행을 지우지 않는다. ima2 서버는 병렬 생성 최대 12건이므로 이 dedup이 없으면 12개 요청이 동시에 refresh_token을 태우고, xAI가 refresh rotation을 하면 11개가 `refresh_token_reused`로 죽는다.
+
+**원자적 0600 쓰기 — `lib/atomicWrite.ts`는 재사용하지 마라.** 현재 구현:
+
+```ts
+// lib/atomicWrite.ts:3-7
+export async function atomicWriteJson(path: string, data: unknown): Promise<void> {
+  const tmp = `${path}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(data));
+  await rename(tmp, path);
+}
+```
+
+`mode` 옵션이 없어 tmp가 umask 기본(보통 0644)으로 생성되고, rename이 그 퍼미션을 그대로 옮긴다. 자격증명 파일이 world-readable이 된다. 게다가 tmp 이름이 `process.pid` 고정이라 같은 프로세스 내 동시 쓰기가 충돌한다. `routes/auth.ts:70-73`이 이미 올바른 패턴을 갖고 있으니 그걸 따른다:
+
+```ts
+const tmp = join(dir, `auth.json.tmp-${randomBytes(6).toString("hex")}`);
+writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+renameSync(tmp, target);
+```
+
+`lib/xaiAuth.ts`는 이 로직을 자체 보유하고(sidecar용 `atomicWrite.ts`와 용도가 다르다), 디렉터리는 `mkdirSync(dir, { recursive: true, mode: 0o700 })`(`routes/auth.ts:50`)로 보장한다. 들여쓰기 2칸 `JSON.stringify(data, null, 2)`도 progrok(`dist/index.js:214`)·ima2(`routes/auth.ts:72`)와 동일하게 유지해 diff 노이즈를 없앤다.
+
+**refresh 실패 처리.** 파일은 **지우지 않는다**. progrok `logout`(`dist/index.js:488-490`)만 `deleteTokens()` 권한을 갖는다. 자동 삭제는 두 가지를 망친다 — 사용자가 재로그인 전까지 `email` 같은 표시용 메타를 잃고, 일시적 오분류(예: 네트워크 장애를 terminal로 오판)가 복구 불가능해진다.
+
+terminal 판정은 OpenCodex `index.ts:602`를 그대로 쓴다:
+
+```ts
+["invalid_grant","refresh_token_reused","revoked_token"].includes(error.oauthError ?? "")
+```
+
+terminal이면 `GrokAuthError("GROK_AUTH_REQUIRED")`, 그 외(네트워크·5xx·429 소진)는 `GROK_AUTH_REFRESH_FAILED`. 이 구분이 UI에서 "재로그인하세요" vs "잠시 후 재시도"를 가른다. 추가로 OpenCodex의 negative-cache(`index.ts:156` `XAI_PERMANENT_FAILURE_TTL_MS=30_000`)를 가져오면 terminal 판정 후 30초간 같은 자격증명으로의 재시도를 즉시 차단할 수 있다 — 12건 병렬에서 죽은 토큰으로 12번 왕복하는 걸 막으므로 권장한다.
+
+**요청 중 401 — 강제 갱신 1회 + 재시도 1회.** 현재 ima2 Grok 이미지 경로는 `Authorization: "Bearer dummy"`(`lib/grokImageCore.ts:72`)로 progrok 프록시에 붙고 실제 베어러 주입은 progrok이 한다(`dist/index.js:553`). 그래서 401 재시도 루프는 `lib/xaiAuth.ts`를 직접 쓰는 새 경로(프록시 우회)에만 필요하다. 사양:
+
+1. 401 수신 → 현재 access token의 generation(예: `access` 문자열의 SHA-256 접두)을 기록.
+2. `getGrokAccessToken({ forceRefresh: true })` 호출. 내부에서 저장된 generation이 이미 바뀌었으면(다른 요청이 먼저 갱신) 갱신 없이 새 토큰 반환 — OpenCodex `index.ts:499` `if (rejectedGeneration !== undefined && current.generation !== rejectedGeneration) return current;`와 같은 조건.
+3. 새 토큰으로 **정확히 1회** 재시도. 다시 401이면 `GROK_AUTH_REQUIRED`로 종결.
+
+**`lib/grokUpstreamRetry.ts`와의 관계 — 401은 이미 제외되어 있고, 그대로 둬야 한다.** `isTransientUpstreamStatus`(`grokUpstreamRetry.ts:29-32`)는 `500, 502, 503, 504, 520, 521, 522`만 재시도하므로 401·403·429는 애초에 통과한다. 401 재시도를 그 모듈에 넣으면 안 되는 이유가 명확하다 — `grokFetchWithRetry`는 같은 `doFetch`를 재실행할 뿐 헤더를 다시 만들지 않아서, 갱신된 토큰이 반영되지 않는 무의미한 재시도가 된다. 401 처리는 헤더를 재구성할 수 있는 호출 계층(어댑터)에 두고, `grokUpstreamRetry.ts`는 "MUST stay a leaf module: no imports from config, routes, or adapters"(`grokUpstreamRetry.ts:12`)라는 자체 계약대로 `lib/xaiAuth.ts`를 import하지 않는다.
+
+한 가지 주의. `lib/grokImageCore.ts:178`은 401/403을 `502 GROK_AUTH_FAILED`로 변환한다. 401 재시도 로직을 이 계층 위에 얹으면 원래 상태 코드가 이미 뭉개진 뒤라 감지가 안 된다. 재시도는 `res.status` 원본을 보는 위치, 즉 `postGrokImages` 내부 `if (!res.ok)` 블록(`grokImageCore.ts:171`) 안에서 처리해야 한다.
+
+## 5. `xai.ts` 결함 감사
+
+Bun/Node 차이는 실제로 실행해 확인했다(Node 24.17.0, undici). 결함과 스타일을 분리한다.
+
+### D1 — `retry-after`가 2000ms 상한에 삼켜진다 (실제 결함)
+
+```ts
+// xai.ts:98
+return Math.min(2000,Math.max(j,seconds*1000));
+```
+
+`Math.min`이 바깥이라 서버가 지정한 대기 시간이 무조건 2초로 잘린다. 실측:
+
+```
+ra=60 -> 2000     // 서버가 60초 요구, 2초 후 재시도
+```
+
+**실패 시나리오.** xAI가 429 + `Retry-After: 60`을 주면 클라이언트는 2초 뒤 재시도해 즉시 또 429를 받고, 3회를 다 태운 뒤 실패한다. 레이트리밋 상황에서 백오프가 사실상 무력화되고 오히려 압박을 가중한다. `Retry-After`는 RFC 9110에서 준수 대상이지 상한 대상이 아니다.
+
+**한 줄 수정.** `retryAfter`가 있으면 그 값을 그대로 쓰고 지터 상한만 2000ms로 제한: `return seconds > 0 ? seconds * 1000 : Math.min(2000, j);` (필요하면 별도의 넉넉한 절대 상한, 예: 60초를 둔다).
+
+참고로 같은 저장소의 ima2 쪽 `retryBackoffDelayMs`(`grokUpstreamRetry.ts:65-70`)도 `Math.min(retryAfter, opts.maxDelayMs)`로 동일 계열의 절삭을 한다. 다만 ima2 쪽은 maxDelay가 5초이고 5xx 재시도 용도라 성격이 다르므로, 이식 시 xAI 토큰 경로에는 절삭 없는 정책을 쓰는 걸 권한다.
+
+### D2 — `retry-after` HTTP-date 형식을 무시한다 (실제 결함)
+
+```ts
+// xai.ts:98
+seconds=retryAfter!==null&&/^\d+$/.test(retryAfter)?Number(retryAfter):0
+```
+
+RFC 9110 `Retry-After`는 delay-seconds와 HTTP-date 두 형식을 모두 허용한다. 정규식이 후자를 버려 `seconds=0`이 되고, 서버 지시가 통째로 사라진다. 실측:
+
+```
+ra=Sun, 06 Nov 1994 08:49:37 GMT -> 100   // 100ms 후 재시도
+```
+
+소수 초(`1.5`)도 같은 이유로 0이 된다. 헤더 앞뒤 공백은 `Headers.get()`이 트림하므로(확인함: `' 30 '` → `"30"`) 문제되지 않는다.
+
+**한 줄 수정.** `grokUpstreamRetry.ts:49-57` `retryAfterDelayMs`처럼 `Number()` 시도 후 실패 시 `Date.parse()` 폴백을 넣는다. 이식 시에는 그 함수를 재사용하는 게 자연스럽다.
+
+### D3 — `isAbortError`가 사용자 지정 abort reason을 놓친다 (실제 결함, 단 통념과는 다른 형태)
+
+```ts
+// xai.ts:97
+function isAbortError(error:unknown):boolean{return error instanceof DOMException&&error.name==="AbortError";}
+```
+
+"Node undici는 plain Error를 던진다"는 가설은 **틀렸다**. Node 24에서 직접 확인:
+
+```
+// AbortSignal.timeout 만료
+ctor DOMException  name TimeoutError  dom true
+// controller.abort() (reason 미지정)
+ctor DOMException  name AbortError    dom true
+```
+
+기본 경로에서는 `DOMException`이 맞다. 진짜 결함은 두 가지다.
+
+첫째, `controller.abort(reason)`으로 커스텀 reason을 주면 undici가 그 reason을 그대로 reject한다:
+
+```
+ctor Error  name Error  dom false  msg user cancel
+```
+
+ima2에는 이 패턴이 실재한다 — `grokUpstreamRetry.ts:73` `return signal?.reason ?? new DOMException(...)`. 즉 ima2 호출자가 커스텀 reason으로 취소하면 `isAbortError`가 false를 반환하고, `xai.ts:114`의 `if(isAbortError(error)&&signal?.aborted)throw error` 가드가 뚫려 **취소된 요청이 두 번 더 재시도된다**.
+
+둘째, `AbortSignal.timeout` 만료는 `name === "TimeoutError"`라 `isAbortError`가 false다. `requestSignal`(`xai.ts:42-45`)이 30초 타임아웃을 항상 합성하므로, 타임아웃 만료 시 재시도 경로로 빠져 총 90초까지 늘어난다. 의도된 동작일 수도 있으나 `TOKEN_REQUEST_TIMEOUT_MS`라는 이름의 계약과는 어긋난다.
+
+**한 줄 수정.** `signal?.aborted`를 1차 판정으로 삼아 에러 타입 의존을 없앤다: `if (signal?.aborted) throw error;` — reason 타입과 무관하게 정확하다. 타임아웃은 별도로 `error.name === "TimeoutError"`를 재시도 불가로 분류.
+
+### D4 — 3회 소진 시 `throw last`가 raw 네트워크 에러를 노출한다 (경미한 결함)
+
+`xai.ts:114` 말미의 `throw last`는 `for` 루프가 정상 종료됐을 때만 도달하는데, 실제로는 `attempt===3` 분기에서 항상 throw하므로 **도달 불가능한 코드**다. TypeScript는 `last: unknown` 타입이라 이를 잡지 못한다. 기능상 무해하지만 `throw`할 수 없는 값(`undefined`)을 던질 수 있는 형태라 정적으로 위험하다. 수정: 루프 후 `throw new XaiTokenRequestError(undefined, undefined, "xAI token request exhausted retries", { cause: last });`.
+
+### D5 — `credentialsFromTokenPayload`의 `expires_in` 기본값 3600 (설계 판단, 조건부 결함)
+
+```ts
+// xai.ts:128-129
+const expiresIn = typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in) ? payload.expires_in : 3600;
+```
+
+서버가 `expires_in`을 안 주면 1시간을 가정한다. 실제 수명이 더 짧으면 만료된 토큰을 최대 1시간 유효하다고 믿고 401을 받는다. `Number.isFinite` 가드 자체는 올바르다(`NaN`/`Infinity` 차단). 다만 progrok은 같은 상황에서 `expiresAt: undefined`(`dist/index.js:196`)로 "모름"을 명시하고 401을 신호로 쓴다 — 더 정직한 처리다. **ima2 이식판은 progrok 쪽을 따라야 한다.** 디스크 스키마가 `expiresAt?: number`로 optional인 이상, 3600을 넣으면 progrok의 "모름" 표현과 충돌한다.
+
+`expires_in`이 문자열로 오는 경우(일부 IdP가 그런다)도 3600 폴백으로 흡수된다. `typeof === "string"`이면 `Number()` 시도를 추가하는 게 안전하다.
+
+### D6 — `validateXaiEndpoint`가 임의 `*.x.ai` 서브도메인과 credential URL을 허용한다 (실제 결함, 낮은 심각도)
+
+```ts
+// xai.ts:50
+if (parsed.protocol !== "https:" || (host !== "x.ai" && !host.endsWith(".x.ai"))) {
+```
+
+두 문제. (1) `.x.ai` 접미사만 보므로 discovery 응답이 오염되면 `https://attacker.x.ai/token`이 통과한다 — x.ai 서브도메인 하나만 탈취되면 refresh_token이 그리로 간다. 다만 discovery 자체가 TLS 고정 호스트라 공격 표면은 좁다. (2) `new URL()`은 userinfo를 보존한다:
+
+```
+https://u:p@auth.x.ai/oauth2/token  →  그대로 통과
+```
+
+`parsed.toString()`이 credential을 포함한 URL을 반환하고 `fetch`가 그걸 Authorization으로 변환할 수 있다. progrok의 `requireTrustedEndpoint`(`dist/index.js:41-50`)도 동일한 약점을 갖는다(원본 `url` 문자열을 그대로 반환하므로 오히려 더 느슨하다).
+
+**한 줄 수정.** 알려진 호스트만 허용하고 userinfo를 거부: `if (parsed.protocol !== "https:" || parsed.username || parsed.password || (host !== "auth.x.ai" && host !== "accounts.x.ai")) throw ...`. progrok이 이미 `XAI_OAUTH_CORS_ORIGINS = ["auth.x.ai", "accounts.x.ai"]`(`dist/index.js:24`)라는 정확한 허용 목록을 갖고 있으니 근거도 있다.
+
+### D7 — `decodeJwtPayload`의 base64url 처리는 정상 (결함 아님)
+
+```ts
+// xai.ts:81
+return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as XaiJwtPayload;
+```
+
+Node의 `"base64url"` 인코딩은 패딩 없는 base64url을 올바로 디코드한다(확인: `eyJlbWFpbCI6ImFAYi5jb20ifQ` → `{"email":"a@b.com"}`). 잘못된 입력은 조용히 쓰레기 바이트를 만들지만 `JSON.parse`가 던지고 `catch`가 `undefined`를 반환하므로(`xai.ts:82-84`) 안전하다. `parts.length !== 3` 검사도 있다. **결함 없음.** 다만 서명 검증을 하지 않으므로 `email`/`sub`는 표시용으로만 써야 한다 — 인가 판단에 쓰면 안 된다. `xai.ts:88`에서 `id_token` 실패 시 `access_token`을 파싱하는데, access token이 JWT가 아닌 불투명 토큰일 수 있어 그때는 `undefined`가 되고 정상 폴백한다.
+
+### D8 — refresh token rotation 폴백은 올바름 (결함 아님, 단 skew 이중 차감 주의)
+
+```ts
+// xai.ts:121-127
+const refresh = typeof payload.refresh_token === "string" && payload.refresh_token.length > 0
+  ? payload.refresh_token : refreshFallback;
+if (!refresh) throw new Error("xAI token response did not include a refresh token");
+```
+
+`refreshXaiToken`이 `refreshToken`을 폴백으로 넘기므로(`xai.ts:240`), rotation을 안 하는 서버에서도 기존 토큰이 보존된다. progrok도 동일 패턴(`dist/index.js:263`). **올바르다.**
+
+다만 `xai.ts:135` `expires: Date.now() + expiresIn * 1000 - XAI_OAUTH_REFRESH_SKEW_MS`는 skew를 차감해 저장한다. 이식 시 이 값을 그대로 `expiresAt`에 쓰면 progrok의 raw 의미론과 충돌해 skew가 두 번 적용된다(§3). 이식판에서는 차감을 제거해야 한다.
+
+### D9 — `postXaiToken`의 응답 body 누수 (경미)
+
+`xai.ts:114`에서 429/5xx 응답은 `readTokenError`가 `response.json()`으로 소비하지만(`xai.ts:99`), `json()`이 던지면 `catch{}`가 삼키고 body가 미소비 상태로 남는다. undici는 GC 시 정리하지만 소켓 재사용이 지연된다. ima2의 `cancelResponseBodyBestEffort`(`grokUpstreamRetry.ts:100-107`)가 이 문제를 명시적으로 다루는 참고 구현이다. 심각도 낮음.
+
+### 스타일 (결함 아님)
+
+`xai.ts:95-99`와 `xai.ts:105-114`의 압축 한 줄 코드는 기능상 정확하지만 리뷰·디버깅을 방해한다. `xai.ts:114`는 한 줄에 fetch·에러 분류·재시도 판정·백오프가 모두 들어 있어 스택 트레이스가 무의미해진다. ima2 규약(`AGENTS.md`: 함수 50줄 미만, 파일 500줄 미만)에도 어긋나므로 이식 시 풀어 쓴다. `xai.ts:96` `XaiTokenRetryDeps`의 `sleep`/`random` 주입은 좋은 설계이므로 유지.
+
+**GitHub 이슈 후보 우선순위:** D1(retry-after 절삭)과 D2(HTTP-date 무시)는 재현이 쉽고 영향이 명확해 단독 이슈로 적합하다. D3(abort reason)은 커스텀 reason을 쓰는 호출자가 있어야 발현하므로 재현 조건을 명시해야 한다. D6(엔드포인트 검증)은 보안 강화 성격으로 별도 이슈. `AGENTS.md` 관례상 버그 하나당 PR 하나로 분리한다.
+
+## 6. 제안 `lib/xaiAuth.ts` 공개 API
+
+```ts
+// lib/xaiAuth.ts — Node 24 ESM. 의존: node:fs, node:crypto, node:os, node:path only.
+// MUST stay a leaf module: no imports from config, routes, or adapters.
+
+export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+export const XAI_TOKEN_REFRESH_SKEW_MS = 120_000;
+export const XAI_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+
+export type GrokAuthErrorCode = "GROK_AUTH_REQUIRED" | "GROK_AUTH_REFRESH_FAILED";
+
+export class GrokAuthError extends Error {
+  readonly code: GrokAuthErrorCode;
+  readonly status: number;           // GROK_AUTH_REQUIRED → 401, REFRESH_FAILED → 502
+  readonly oauthError?: string;      // invalid_grant 등 원문 보존
+  constructor(code: GrokAuthErrorCode, message: string,
+              options?: { oauthError?: string; cause?: unknown });
+}
+
+/** ~/.progrok/auth.json 온디스크 형태. progrok 0.2.0과 바이트 호환. */
+export interface GrokCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;                // epoch ms, RAW (skew 미차감)
+  tokenEndpoint?: string;
+  email?: string;
+  idToken?: string;                  // 존재 시 반드시 보존
+  accountId?: string;
+}
+
+export interface XaiDiscovery {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  deviceAuthorizationEndpoint?: string;
+}
+
+export interface XaiTokenRetryDeps {
+  sleep?: (ms: number) => Promise<void>;   // 기본: setTimeout 기반 (Bun.sleep 대체)
+  random?: () => number;
+  now?: () => number;
+}
+
+export function grokAuthFilePath(homeDir?: string): string;
+
+/** 파일 부재/파싱 실패 시 null. 절대 throw하지 않는다. */
+export function loadGrokCredentials(homeDir?: string): GrokCredentials | null;
+
+/** 원자적 0600 쓰기 (tmp + rename). 디렉터리는 0700으로 보장. */
+export function saveGrokCredentials(creds: GrokCredentials, homeDir?: string): void;
+
+/** 파일 삭제. 명시적 logout에서만 호출. refresh 실패는 삭제하지 않는다. */
+export function clearGrokCredentials(homeDir?: string): void;
+
+export function discoverXaiOAuthEndpoints(signal?: AbortSignal): Promise<XaiDiscovery>;
+
+export function postXaiToken(
+  tokenEndpoint: string,
+  body: Record<string, string>,
+  signal?: AbortSignal,
+  deps?: XaiTokenRetryDeps,
+): Promise<XaiTokenPayload>;
+
+export function refreshXaiToken(
+  refreshToken: string,
+  opts?: { tokenEndpoint?: string; signal?: AbortSignal; deps?: XaiTokenRetryDeps },
+): Promise<GrokCredentials>;
+
+export interface GetAccessTokenOptions {
+  forceRefresh?: boolean;
+  /** 401을 받은 토큰. 저장된 토큰이 이미 다르면 갱신 없이 새 토큰 반환. */
+  rejectedAccessToken?: string;
+  signal?: AbortSignal;
+  homeDir?: string;
+}
+
+/**
+ * 유효한 access token 반환. 만료 임박(skew 120s) 또는 forceRefresh 시 갱신 후 저장.
+ * 자격증명 없음/refresh 없음/terminal 실패 → GrokAuthError("GROK_AUTH_REQUIRED")
+ * 네트워크·5xx·429 소진 → GrokAuthError("GROK_AUTH_REFRESH_FAILED")
+ */
+export function getGrokAccessToken(opts?: GetAccessTokenOptions): Promise<string>;
+
+/** 테스트 전용: single-flight와 negative-cache 초기화. */
+export function __resetGrokAuthStateForTest(): void;
+```
+
+single-flight 메커니즘은 모듈 내부에 캡슐화한다:
+
+```ts
+let refreshFlight: { promise: Promise<GrokCredentials>; startedAt: number; token: string } | undefined;
+const FLIGHT_STALE_MS = 120_000;          // OpenCodex index.ts:114와 동일
+const TERMINAL_FAILURE_TTL_MS = 30_000;   // OpenCodex index.ts:156과 동일
+let terminalFailureUntil = 0;
+```
+
+동작 규칙 넷. 조인 — 진행 중 비행이 `FLIGHT_STALE_MS` 이내면 그 promise를 공유한다. 세대 확인 — `rejectedAccessToken`이 주어졌고 디스크의 `accessToken`이 이미 다르면 갱신 없이 즉시 반환한다(`index.ts:499` 패턴). 자기 해제 — `finally`에서 `refreshFlight`가 자기 자신일 때만 `undefined`로 되돌린다(`index.ts:537` 패턴). 부정 캐시 — terminal 실패 후 `TERMINAL_FAILURE_TTL_MS` 동안 네트워크 왕복 없이 `GROK_AUTH_REQUIRED`를 즉시 던진다.
+
+호출자 계약: `getGrokAccessToken()`은 매 요청 앞에서 호출하고 반환값을 캐시하지 않는다. 401을 받으면 `{ forceRefresh: true, rejectedAccessToken: <방금 쓴 토큰> }`으로 한 번만 재호출하고, 성공 시 요청을 한 번만 재시도한다. 두 번째 401은 `GROK_AUTH_REQUIRED`로 종결한다.
+
+한 가지 미해결 사항을 남긴다. `lib/xaiAuth.ts`가 자격증명 파일을 갱신하면 별도 프로세스인 progrok이 그 변경을 자동 감지하지 않는다 — progrok은 요청마다 `loadTokens()`를 다시 읽으므로(`dist/index.js:229`) 실제로는 다음 요청에서 새 토큰을 집는다. 반대 방향, 즉 progrok이 갱신한 뒤 ima2의 인메모리 상태가 낡는 경우는 `loadGrokCredentials()`를 매번 디스크에서 읽는 설계로 회피된다. 인메모리 캐시를 도입하면 이 안전성이 깨지므로, 캐시 없이 파일을 진실의 원천으로 유지하는 걸 사양에 못박아 둔다.
+
+

--- a/devlog/_plan/260909_grok_native_oauth/002_callsite_inventory.md
+++ b/devlog/_plan/260909_grok_native_oauth/002_callsite_inventory.md
@@ -1,0 +1,557 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, progrok, research]
+---
+
+# 002 — Grok 프록시 도달 경로 전수 조사 (opus-5 explorer, 2026-09-09)
+
+읽기 전용 조사. 대상 dev @ 11900764 (v3.15.1). 본문은 파견 결과를 그대로 보존하고,
+000_plan.md에서 결정으로 승격된 항목만 별도로 요약한다.
+
+
+# Grok 프록시(progrok) 도달 경로 전수 조사
+
+조사 대상: `/Users/jun/.codex/worktrees/6563/ima2-gen`, `dev` @ `11900764` (v3.15.1). 읽기 전용, 편집·커밋·테스트 실행 없음.
+
+## 0. 현재 구조 요약
+
+프록시 URL을 만드는 단일 지점은 두 개뿐이고 나머지는 전부 이 둘을 경유한다.
+
+- `lib/grokImageCore.ts:62` `getGrokEndpoint(ctx, path, directApiKey?)` — 이미지/플래너/검색/프롬프트빌더용
+- `lib/grokVideoShared.ts:113` `videoEndpoint(ctx, path, directApiKey?)` — 비디오용
+
+예외적으로 `routes/videoExtended.ts:69` `videoProxyUrl()`이 세 번째 복제본으로 존재하며, 이건 `directApiKey`를 아예 받지 않는다.
+
+```ts
+// lib/grokRuntime.ts:20-26
+export function getGrokProxyUrl(ctx: RouteRuntimeContext = {}, path = "/v1"): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${getGrokProxyBaseUrl(ctx)}${normalizedPath}`;
+}
+
+export function getGrokDirectBaseUrl(): string {
+  return "https://api.x.ai";
+}
+```
+
+`getGrokDirectBaseUrl()`은 정의만 있고 호출자가 없다 (`rg -n 'getGrokDirectBaseUrl' . --glob '!node_modules'` → `lib/grokRuntime.ts:25` 한 줄). 두 엔드포인트 함수는 `https://api.x.ai`를 리터럴로 박아 쓴다. 통합 시 이 함수를 실제 단일 상수원으로 승격시키면 된다.
+
+## 1. 전체 도달 경로 표
+
+### 1-A. 이미지 lane
+
+| file:line | function | 현재 엔드포인트 해석 | auth 헤더 출처 | lane | 변경 |
+|---|---|---|---|---|---|
+| `lib/grokImageCore.ts:62-74` | `getGrokEndpoint` | `directApiKey` 있으면 `https://api.x.ai${path}`, 없으면 `getGrokProxyUrl(ctx, path)` | `Bearer ${directApiKey}` / `Bearer dummy` | grok, grok-api 공용 | credential 인자로 교체, 항상 `https://api.x.ai` |
+| `lib/grokImageCore.ts:150-157` | `postGrokImages` | `getGrokEndpoint(ctx, path, directApiKey)` | 위 상속 | 양쪽 | `directApiKey?: string` → `credential` 전파 |
+| `lib/providers/adapters/grokOperations.ts:52` | `generateViaGrok` | `postGrokImages(..., endpoint, options.directApiKey)` (`/v1/images/generations` \| `/v1/images/edits`) | 위 상속 | 양쪽 | 옵션 필드명 교체 |
+| `lib/providers/adapters/grokOperations.ts:58-61` | `generateViaGrok` 다운로드 | `downloadGrokImageUrl(..., { trustedProxyOrigin: directApiKey ? undefined : new URL(getGrokProxyBaseUrl(ctx)).origin })` | — | grok만 trustedOrigin 부여 | `trustedProxyOrigin` 항상 `undefined`, 호출부 3곳 삭제 |
+| `lib/providers/adapters/grokOperations.ts:86,91-94` | `editViaGrok` | `/v1/images/edits` + 동일 다운로드 정책 | 위 상속 | 양쪽 | 동일 |
+| `lib/providers/adapters/grokMultimodeOperations.ts:98,101-104` | `generateMultimodeViaGrok` | 루프 내 `postGrokImages` + 다운로드 정책 | 위 상속 | 양쪽 | 동일 |
+| `lib/providers/adapters/grokExecution.ts:27,35,49` | `prepareGrokClassic` | `activeProvider === "grok-api" ? ctx.xaiApiKey : undefined` | ctx | 분기 지점 | `await resolveGrokCredential(ctx, provider)` |
+| `lib/providers/adapters/grokExecution.ts:59,61` | `prepareGrokNode` | 동일 | ctx | 분기 | 동일 |
+| `lib/providers/adapters/grokExecution.ts:84,87` | `executeGrokEdit` | 동일 | ctx | 분기 | 동일 |
+| `lib/providers/adapters/grokExecution.ts:96,101` | `executeGrokMultimode` | 동일 | ctx | 분기 | 동일 |
+
+`grokExecution.ts`의 네 곳이 이미지 lane에서 프록시/직결을 가르는 **유일한 분기점**이다. 전부 같은 한 줄이다.
+
+```ts
+// lib/providers/adapters/grokExecution.ts:27
+const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined;
+```
+
+### 1-B. 비디오 lane
+
+| file:line | function | 현재 엔드포인트 해석 | auth 헤더 출처 | lane | 변경 |
+|---|---|---|---|---|---|
+| `lib/grokVideoShared.ts:113-125` | `videoEndpoint` | `directApiKey` 유무로 `https://api.x.ai` / 프록시 | `Bearer ${directApiKey}` / `Bearer dummy` | 양쪽 | credential 인자로 교체 |
+| `lib/grokVideoAdapter.ts:282` | `planGrokVideo` | `videoEndpoint(ctx, "/v1/chat/completions", options.directApiKey)` | 위 상속 | 양쪽 | 전파 |
+| `lib/grokVideoAdapter.ts:247` | `planGrokVideo` 검색 | `searchGrokVisualContext(...)` → `getGrokEndpoint(ctx,"/v1/responses",directApiKey)` | 위 상속 | 양쪽 | 전파 |
+| `lib/grokVideoAdapter.ts:398` | `startVideoRequest` | `videoEndpoint(ctx, "/v1/videos/generations", options.directApiKey)` | 위 상속 | 양쪽 | 전파. 재시도 금지 규약 유지 |
+| `lib/grokVideoPoll.ts:45` | `pollVideoOnce` | `videoEndpoint(ctx, \`/v1/videos/${requestId}\`, directApiKey)` | 위 상속 | 양쪽 | 전파 |
+| `lib/grokVideoPoll.ts:91` | `pollVideoUntilDone` | `options.directApiKey` 전달 | ctx→options | 양쪽 | 전파 |
+| `lib/grokVideoDownload.ts:142-153` | `downloadVideo` | 프록시 아님. poll이 준 `poll.video.url`을 그대로 fetch, **Authorization 헤더 없음** | 없음 | 공통 | 변경 없음 |
+| `routes/video.ts:543,558` | `POST /api/video` | `provider === "grok-api" ? ctx.xaiApiKey : undefined` | ctx | 분기 | credential 해석으로 교체 |
+| `lib/videoExtendI2vOperation.ts:68` | i2v extend | `provider === "grok-api" ? ctx.xaiApiKey ?? undefined : undefined` | ctx | 분기 | 동일 |
+| `routes/videoExtended.ts:69-70` | `videoProxyUrl` | **무조건 프록시 + `Bearer dummy`** | 하드코딩 | grok 전용 | 삭제하고 `videoEndpoint`로 통합 |
+| `routes/videoExtended.ts:206` | `POST /api/video/edit` | `videoProxyUrl(ctx,"/v1/videos/edits")` | `Bearer dummy` | grok 전용 | credential 필요 |
+| `routes/videoExtended.ts:341` | `POST /api/video/extend/native` | `videoProxyUrl(ctx,"/v1/videos/extensions")` | `Bearer dummy` | grok 전용 | credential 필요 |
+| `routes/videoExtended.ts:435` | 프레임 분석 | `videoProxyUrl(ctx,"/v1/responses")` | `Bearer dummy` | grok 전용 | credential 필요 |
+
+`routes/videoExtended.ts`의 세 라우트는 현재 `grok-api` 키를 절대 쓰지 않는다. 직결 전환 시 여기가 유일하게 "credential 인자가 존재하지도 않는" 신규 배선 지점이다.
+
+```ts
+// routes/videoExtended.ts:69-70
+function videoProxyUrl(ctx: RuntimeContext, path: string) {
+  return { url: getGrokProxyUrl(ctx, path), headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" } };
+}
+```
+
+### 1-C. planner / chat lane
+
+| file:line | function | 현재 엔드포인트 | auth | lane | 변경 |
+|---|---|---|---|---|---|
+| `lib/grokImagePlanner.ts:212` | `searchGrokVisualContext` | `getGrokEndpoint(ctx, "/v1/responses", options.directApiKey)` | 상속 | 양쪽 | 전파 |
+| `lib/grokImagePlanner.ts:310` | `planGrokImage` | `getGrokEndpoint(ctx, "/v1/chat/completions", options.directApiKey)` | 상속 | 양쪽 | 전파 |
+| `lib/agentPlannerModel.ts:115` | `requestGrokPlan` | `getGrokEndpoint(ctx, "/v1/chat/completions")` — **인자 없음 = 항상 프록시** | `Bearer dummy` | grok 전용 | credential 해석 필요 |
+| `lib/promptBuilder/router.ts:107-111` | 백엔드 라우팅 | `backend === "grok-api" ? ctx.xaiApiKey : undefined` 후 `getGrokEndpoint` | ctx | 양쪽 | 아래 인용 참조 |
+
+```ts
+// lib/agentPlannerModel.ts:115  — grok 세션 플래너는 무조건 프록시
+const { url, headers } = getGrokEndpoint(ctx, "/v1/chat/completions");
+```
+
+```ts
+// lib/promptBuilder/router.ts:107-112
+const directApiKey = backend === "grok-api" ? ctx.xaiApiKey : undefined;
+if (backend === "grok-api" && !directApiKey) {
+  throw unavailableBackendError("grok-api");
+}
+const target = getGrokEndpoint(ctx, "/v1/chat/completions", directApiKey);
+return { ...target, useOAuthFetch: false };
+```
+
+`promptBuilder/router.ts`는 `grok-api`에만 사전 키 검사를 하고 `grok`은 무검사로 프록시에 넘긴다. 통합 후에는 두 백엔드 모두 `unavailableBackendError`가 걸릴 수 있어야 한다.
+
+### 1-D. models / health / quota / status
+
+| file:line | function | 현재 | 변경 |
+|---|---|---|---|
+| `routes/grok.ts:13` | `GET /api/grok/status` | 프록시로 실 `GET /v1/models` 호출 (`getGrokProxyUrl(ctx,"/v1/models")`), 인증 헤더 없음(프록시가 주입) | 직결 `https://api.x.ai/v1/models` + `Bearer <oauth token>` |
+| `routes/grok.ts:11,22` | probe token | `ctx.grokProxy?.probeToken()` / `markProbedReady` | 프록시 supervisor 소멸 시 삭제 |
+| `routes/models.ts:140-161` | `grokLaneState` | `ctx.grokUrl` 존재 + `ctx.grokProxy?.state` 스위치 | credential 상태 기반으로 재정의 |
+| `routes/models.ts:178-184` | `grokApiLane` | `ctx.xaiApiKey` 유무만 | 유지 |
+| `routes/health.ts:20-24` | `runtimePorts().grok` | `configuredPort/actualPort/url` 노출 | 프록시 포트 개념 소멸 |
+| `server.ts:307,326-330` | `buildAdvertisePayload` | `grokProxyLive` → `actualPort/url/live` | 동일 |
+| `bin/commands/service.ts:142-147` | service doctor | `grok.live === false` 판정 | 동일 |
+| `routes/quota.ts:98-125,222-270` | `fetchGrokBilling` | **프록시 미경유**. `~/.grok/auth.json` + `~/.progrok/auth.json` 토큰을 직접 읽어 `cli-chat-proxy.grok.com`에 붙음 | 토큰 소스 공유 가능, 엔드포인트는 그대로 |
+
+quota는 이미 progrok 프로세스가 아니라 progrok의 **자격증명 파일**만 읽는다. 이게 OAuth 토큰 재사용의 기존 선례다.
+
+```ts
+// routes/quota.ts:120-128
+    const auth = JSON.parse(readFileSync(join(homeDir, ".progrok", "auth.json"), "utf8")) as { accessToken?: string };
+    if (typeof auth.accessToken === "string" && auth.accessToken.trim()) {
+      candidates.push({
+        token: auth.accessToken,
+        source: "progrok:auth-json",
+```
+
+### 1-E. 프록시 프로세스 수명주기 (통합 시 전부 소멸 후보)
+
+| file:line | 내용 |
+|---|---|
+| `lib/grokProxyLauncher.ts:1-325` | 전체 supervisor. spawn/backoff/`waiting-for-login`/probe token |
+| `server.ts:18,489-515` | `startGrokProxy` 호출, `grokProxyLive` 갱신 |
+| `server.ts:390,401-403` | `grokPort`, `grokActualPort`, `grokUrl` 초기화 |
+| `lib/runtimeContext.ts:22-28,116-123,197-199` | ctx 필드 및 기본값 |
+| `routes/auth.ts:258` | 로그인 완료 시 `ctx?.grokProxy?.notifyCredentialsChanged()` |
+| `bin/commands/grok.ts:1-80` | `ima2 grok login/logout/status/models/proxy` → progrok 바이너리 spawn |
+| `package.json:102,112` | `"progrok": "file:vendor/progrok-0.2.0.tgz"` + bundledDependencies |
+| `config.ts:378-410` | `grokProvider.proxyPort/proxyHost/autoStart/restart*` |
+
+## 2. 통합 후 `getGrokEndpoint` 형태
+
+### 권장 시그니처
+
+토큰 갱신이 비동기이므로 credential 해석과 URL 조립을 분리하는 편이 낫다. 호출부 대부분은 이미 async 함수 안에 있다.
+
+```ts
+// lib/grokRuntime.ts (신규)
+export type GrokCredential =
+  | { kind: "api-key"; key: string }
+  | { kind: "oauth"; token: string };
+
+export function grokAuthHeaders(credential: GrokCredential): Record<string, string> {
+  const bearer = credential.kind === "api-key" ? credential.key : credential.token;
+  return { "Content-Type": "application/json", Authorization: `Bearer ${bearer}` };
+}
+
+/** 유일한 credential 해석 지점. oauth는 만료 임박 시 refresh까지 수행. */
+export async function resolveGrokCredential(
+  ctx: RouteRuntimeContext,
+  provider: "grok" | "grok-api",
+): Promise<GrokCredential> { /* §5 참조 */ }
+```
+
+### `lib/grokImageCore.ts:62-74` before/after
+
+```ts
+// BEFORE — lib/grokImageCore.ts:62-74
+export function getGrokEndpoint(ctx: RouteRuntimeContext, path = "/v1/images/generations", directApiKey?: string): { url: string; headers: Record<string, string> } {
+  if (directApiKey) {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return {
+      url: `https://api.x.ai${normalizedPath}`,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${directApiKey}` },
+    };
+  }
+  return {
+    url: getGrokProxyUrl(ctx, path),
+    headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" },
+  };
+}
+```
+
+```ts
+// AFTER
+export function getGrokEndpoint(
+  _ctx: RouteRuntimeContext,
+  path = "/v1/images/generations",
+  credential: GrokCredential,
+): { url: string; headers: Record<string, string> } {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return {
+    url: `${getGrokDirectBaseUrl()}${normalizedPath}`,
+    headers: grokAuthHeaders(credential),
+  };
+}
+```
+
+`ctx`는 시그니처 호환을 위해 남기되 미사용이다. 완전 제거하면 호출부 9곳을 전부 손봐야 하므로 1차 diff에서는 유지하는 쪽이 리뷰 범위가 작다.
+
+### `lib/grokVideoShared.ts:113-125` before/after
+
+```ts
+// BEFORE — lib/grokVideoShared.ts:113-125
+export function videoEndpoint(ctx: RouteRuntimeContext, path: string, directApiKey?: string) {
+  if (directApiKey) {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return {
+      url: `https://api.x.ai${normalizedPath}`,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${directApiKey}` },
+    };
+  }
+  return {
+    url: getGrokProxyUrl(ctx, path),
+    headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" },
+  };
+}
+```
+
+```ts
+// AFTER — grokRuntime의 한 구현으로 위임. grokVideoShared는 re-export만.
+export { getGrokEndpoint as videoEndpoint } from "./grokImageCore.js";
+```
+
+두 함수가 문자 단위로 동일하므로 통합 후 별도 구현을 유지할 이유가 사라진다. `grokVideoShared.ts:1-11`의 "leaf 유지" 주석 규약은 `grokRuntime.ts`가 이미 leaf라서 깨지지 않는다.
+
+### `GrokVideoOptions` 필드 변경
+
+```ts
+// BEFORE — lib/grokVideoShared.ts:59
+  directApiKey?: string | undefined;
+// AFTER
+  credential?: GrokCredential | undefined;
+```
+
+동일 필드가 `lib/grokImagePlanner.ts:207,283`, `lib/providers/adapters/grokOperations.ts:28,79`, `grokMultimodeOperations.ts:48`, `grokVideoPoll.ts:42`에 반복 선언되어 있어 총 7개 선언을 함께 바꿔야 한다.
+
+## 3. 프록시 readiness 소비자 전수 + 새 의미론
+
+새 상태 모델 제안: `credential-ready` (토큰/키 보유 + 만료 전) / `credential-missing` / `refresh-failed`.
+
+| file:line | 현재 판정 | 새 의미론 |
+|---|---|---|
+| `routes/grok.ts:11` | `ctx.grokProxy?.probeToken()` | 삭제. probe generation 개념 자체가 프록시 자식 프로세스 전용 |
+| `routes/grok.ts:13` | 프록시 `/v1/models` 200 여부 | `https://api.x.ai/v1/models` + OAuth Bearer. 401이면 `offline` 대신 refresh 1회 후 재판정 |
+| `routes/grok.ts:22` | `markProbedReady(token, base)` | 삭제 |
+| `routes/grok.ts:25,30` | `state: ctx.grokProxy?.state` | credential 상태 문자열로 대체 |
+| `routes/models.ts:141` | `if (!ctx.grokUrl) → disconnected "Grok proxy not configured"` | credential 없음 → `key-missing`/`disconnected` |
+| `routes/models.ts:142-160` | supervisor state 7분기 | 3분기로 축소 |
+| `server.ts:307,326-330` | `grokProxyLive` → advertise `grok.live` | live 개념 소멸. 필드 제거 또는 credential 보유 여부로 재정의 |
+| `server.ts:499,504,510` | onPortSelected/onReady/onExit에서 갱신 | 삭제 |
+| `bin/commands/service.ts:142-147` | `grok.live === false` 경고 | advertise 스키마 변경에 동반 수정 |
+| `routes/health.ts:20-24` | grok 포트/URL 노출 | 제거 또는 `{ auth: "oauth" | "none" }` |
+| `lib/runtimeContext.ts:22-28` | `grokActualPort/grokPort/grokUrl/grokProxy/grokProxyLive` | 전부 제거 대상 |
+| `routes/auth.ts:258` | 로그인 후 supervisor 재무장 | 토큰 캐시 무효화 훅으로 대체 |
+
+### 현행 lane 판정 (인용)
+
+```ts
+// routes/models.ts:140-161
+function grokLaneState(ctx: RuntimeContext): LaneState {
+  if (!ctx.grokUrl) return { status: "disconnected", reason: "Grok proxy not configured" };
+  switch (ctx.grokProxy?.state) {
+    case "ready":
+      return { status: "ready" };
+    case "starting":
+      return { status: "ready", reason: UNPROBED_GROK_REASON };
+    case "backoff":
+      return { status: "disconnected", reason: "Grok proxy restarting" };
+    case "gave-up-retryable":
+      return { status: "ready", reason: UNPROBED_GROK_REASON };
+    case "waiting-for-login":
+      return { status: "disconnected", reason: "Grok login required" };
+    case "gave-up":
+      return { status: "disconnected", reason: "Grok proxy failed to start" };
+    case "stopped":
+      return { status: "disconnected", reason: "Grok proxy stopped" };
+    default:
+      return { status: "ready", reason: UNPROBED_GROK_REASON };
+  }
+}
+```
+
+`UNPROBED_GROK_REASON`은 `routes/models.ts:130`의 `"configured proxy endpoint; live session not probed"`다. 직결 후에는 "프로브되지 않은 낙관적 ready" 상태 자체가 불필요하다. 토큰 존재 여부는 동기적으로 확실히 알 수 있기 때문이다.
+
+### UI가 기대하는 문자열 (계약)
+
+`ui/src/hooks/useGrokStatus.ts:5-9`가 `/api/grok/status` 응답의 타입 계약이다.
+
+```ts
+export interface GrokStatus {
+  status: "ready" | "no_image_model" | "error" | "offline";
+  models?: string[];
+  reason?: string;
+}
+```
+
+이 4개 리터럴을 소비하는 곳:
+
+- `ui/src/hooks/useProviderAvailability.ts:40-49` — `ready` / `offline` / `no_image_model` / `error` 4분기, 그 외는 빈 문자열
+- `ui/src/hooks/useProviderAvailability.ts:65-69` — `grok: { ok: grokReady, reason, hint: t("provider.grokOfflineHint") }`
+- `ui/src/hooks/useProviderAvailability.ts:70-73` — `"grok-api": { ok: xaiKeyOk, reason: t("provider.xaiApiKeyRequired") }` (`keyStatus?.xai?.valid`, 프록시 무관)
+- `ui/src/components/OnboardingPopup.tsx:31` — `grok?.status === "offline" || grok?.status === "error"` 를 미인증으로 간주
+- `ui/src/components/AccountSettings.tsx:116-117` — `statusTone(grok?.status)` / `statusLabel(t, grok?.status)`
+- `ui/src/hooks/useGrokStatus.ts:28-30` — `status !== "ready"`면 10초 재폴링. `ui/src/hooks/useGrokStatus.ts:32`는 fetch 실패 시 `{ status: "offline" }`
+
+i18n 문자열 중 프록시를 명시적으로 언급해 수정이 필요한 것:
+
+```
+ui/src/i18n/ko.json:740  "grokOffline": "Grok 프록시가 실행되지 않고 있습니다."
+ui/src/i18n/ko.json:743  "grokOfflineHint": "필요하면 `ima2 grok login`을 한 번 실행한 뒤 `ima2 serve`를 시작하세요. ima2가 번들된 Grok 프록시를 자동으로 띄웁니다."
+ui/src/i18n/ko.json:360  "grokApiBody": "번들 progrok에서 필수 검색 → Grok 4.5 이미지·텍스트 도구 기획(영어 프롬프트) → xAI Images API 순서로 실행합니다. ..."
+```
+
+`en.json:740,743,360`, `zh-Hans`, `zh-Hant` 동일 키에 같은 내용이 있다. `readiness.grokApiBody`는 `ui/src/components/ProviderReadinessPopup.tsx:100-101`에서 `provider === "grok"`일 때만 표시된다 (`ProviderReadinessPopup.tsx:41`의 `const isGrok = provider === "grok"`).
+
+`ui/src/components/SettingsWorkspace.tsx:220-225`의 `settings.grokCompatibility.*`도 `provider === "grok"` 조건부다.
+
+**status 리터럴을 유지한 채 의미만 재매핑하는 것이 UI 변경을 최소화한다:**
+
+- `ready` = credential 유효 + `/v1/models`에 `grok-imagine*` 존재
+- `no_image_model` = 인증은 됐으나 이미지 모델 없음 (그대로)
+- `offline` = credential 없음 (문구만 "로그인 필요"로 교체)
+- `error` = refresh 실패 또는 401/5xx
+
+## 4. `grok` vs `grok-api` 차이 — auth 헤더 외 전부
+
+`rg 'grok-api' lib routes` 기준 행동 분기 전수.
+
+### 실제로 다른 것
+
+| 위치 | 분기 | 통합 후 |
+|---|---|---|
+| `lib/providers/registry.ts:73` vs `94-101` | credentials 종류: `{kind:"oauth-proxy", envVars:["IMA2_GROK_PROXY_HOST","IMA2_GROK_PROXY_PORT"], configKey:"grokProvider"}` vs `{kind:"api-key", keyVocabulary:"xai", envVars:["XAI_API_KEY"], keyPrefix:"xai-", validateUrl:"https://api.x.ai/v1/models", configKey:"xaiApiKey"}` | **잔존**. `oauth-proxy` → `oauth`로 kind 변경, env는 무의미해짐 |
+| `lib/providers/execution/admission.ts:14` | `grok-api`만 키 없으면 401 `GROK_API_KEY_MISSING` | grok도 대칭 검사 필요 (`GROK_OAUTH_MISSING`) |
+| `routes/models.ts:178-184` | `grokApiLane`은 `ctx.xaiApiKey`만 보고, models/defaults는 `grokLane(ctx,"grok-api")` 재사용 | 두 lane 판정 로직이 대칭이 됨 |
+| `lib/promptBuilder/router.ts:107-110` | `grok-api`만 사전 키 검사 | 대칭화 |
+| `lib/agentPlannerModel.ts:78` | `input.settings.provider === "grok"`만 `requestGrokPlan` 경유. `grok-api`는 `requestResponsesPlan`으로 빠짐 | grok-api도 xAI로 보낼지 결정 필요 (별건) |
+| `routes/videoExtended.ts:284,101` | extend는 `grok`/`grok-api` 모두 허용하나 edit/native/analyze 3개 라우트는 프록시 고정 | 통합으로 해소 |
+| 다운로드 정책 | `grokOperations.ts:59-60`, `:92-93`, `grokMultimodeOperations.ts:102-103` — grok만 `trustedProxyOrigin` 부여 | **소멸**. 직결 URL은 항상 공개 https라 SSRF 예외가 불필요 |
+
+### 사실상 동일한 것 (registry 메타데이터로 잔존)
+
+`lib/providers/registry.ts:71-88` vs `92-115` 비교:
+
+- `surfaces`: 양쪽 `["generate","edit","multimode","node","video"]` 동일
+- `vendor`: 양쪽 `"xai"`
+- `models`: 5개 항목 문자 단위 동일 (`grok-imagine-image-2.0`, `-image`, `-image-quality`, `grok-imagine-video`, `grok-imagine-video-1.5` + aliases)
+- `referenceLimits`: 양쪽 `{ image: 5, edit: 5, video: 14 }`
+- `elementTaxonomy`: 양쪽 `"grok"`
+- `limits.timeoutMs`: 양쪽 `300_000`
+- `errorPrefix`: 양쪽 `"GROK_"`
+
+`grok-api` 쪽 주석이 이미 이 사실을 인정한다:
+
+```ts
+// lib/providers/registry.ts:109-112
+    // Same upstream as the grok lane, reached with a direct key instead of the proxy, so
+    // the caps are taken to match. The 5 was measured on the proxy path only; if an edit
+    // fails at 4-5 images with a direct key, this assumption is the place to look.
+    referenceLimits: { image: 5, edit: 5, video: 14 },
+```
+
+### 파이프라인의 `grok || grok-api` OR 조건 (통합 후에도 잔존, 축소 불가)
+
+두 lane이 별도 provider id로 남는 한 아래는 그대로다. 실행 경로가 아니라 provider id 분류이기 때문이다.
+
+- `lib/generatePipeline.ts:233,291,295,397,478,514,604`
+- `lib/multimodePipeline.ts:48,280,302,305,308`
+- `lib/nodeGeneration.ts:101,150,301,333`
+- `routes/edit.ts:271,274,296`
+- `lib/providers/execution/legacy.ts:9,14`
+- `lib/providerOptions.ts:100-123` (두 블록이 provider 문자열만 다른 복제)
+- `ui/src/lib/coreSelection.ts:73,137`
+
+## 5. 401 처리 현황과 단일 refresh 훅 위치
+
+### 현재: progrok가 투명하게 갱신하고, ima2는 401을 사실상 못 본다
+
+progrok는 매 요청마다 `getValidBearer()`를 호출해 만료 2분 전이면 refresh 한다.
+
+```js
+// node_modules/progrok/dist/index.js:28
+var TOKEN_REFRESH_SKEW_MS = 2 * 60 * 1e3;
+
+// :235-246
+  if (tokens.expiresAt && Date.now() + TOKEN_REFRESH_SKEW_MS >= tokens.expiresAt) {
+    if (!tokens.refreshToken || !tokens.tokenEndpoint) {
+      throw new Error("Token expired and no refresh token available. Run `progrok login` again.");
+    }
+    log.dim("Refreshing access token...");
+    const res = await fetch(tokens.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ grant_type: "refresh_token", client_id: XAI_OAUTH_CLIENT_ID, refresh_token: tokens.refreshToken }),
+```
+
+```js
+// node_modules/progrok/dist/index.js:531-545
+async function handleProxy(req, res) {
+  const relPath = req.path.replace(/^\/v1/, "");
+  let bearer;
+  try {
+    bearer = await getValidBearer();
+  } catch (err) {
+    res.status(401).json({ error: { message: err.message, type: "auth_error" } });
+    return;
+  }
+  ...
+  fwdHeaders["Authorization"] = `Bearer ${bearer}`;
+```
+
+즉 ima2가 401을 보는 경우는 refresh 자체가 실패했을 때뿐이고, 그때는 재시도해도 소용없다. 이것이 현재 재시도 술어가 401을 전혀 다루지 않는 이유다.
+
+### `lib/grokUpstreamRetry.ts` 재시도 술어 전문
+
+```ts
+// lib/grokUpstreamRetry.ts:28-47
+/** Gateway-class statuses. 507 is storage-class, not transient, and is excluded. */
+export function isTransientUpstreamStatus(status: number): boolean {
+  return status === 500 || status === 502 || status === 503 || status === 504
+    || status === 520 || status === 521 || status === 522;
+}
+
+export function isConnectionResetError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // Aborts and timeouts are caller decisions / honest failures — never retryable.
+  if (err.name === "AbortError" || err.name === "TimeoutError") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === "ECONNRESET" || code === "EPIPE") return true;
+  const cause = (err as { cause?: unknown }).cause;
+  const causeCode = cause && typeof cause === "object" ? (cause as { code?: unknown }).code : undefined;
+  if (causeCode === "ECONNRESET" || causeCode === "EPIPE") return true;
+  const msg = err.message.toLowerCase();
+  return msg.includes("socket connection was closed unexpectedly")
+    || msg.includes("connection reset by peer")
+    || msg.includes("socket hang up");
+}
+```
+
+401은 어디에도 없다. `grokFetchWithRetry`(`:141-163`)는 `isTransientUpstreamStatus`만 보므로 401은 첫 응답 그대로 반환된다.
+
+ima2의 401 취급은 두 군데다.
+
+```ts
+// lib/grokImageCore.ts:178
+      if (res.status === 401 || res.status === 403) throw grokError(`Grok auth failed: ${msg}`, 502, "GROK_AUTH_FAILED");
+// lib/grokImageCore.ts:90 (grokStageError)
+  if (status === 401 || status === 403) return grokError(`${stage} auth failed: ${message}`, 502, "GROK_AUTH_FAILED");
+```
+
+비디오 쪽은 401 전용 매핑이 없다. `grokVideoPoll.ts:55`는 `res.status >= 500 ? 502 : res.status`로 401을 그대로 흘리고, `isRecoverablePollError`(`:29-36`)는 `status >= 500 || status === 429`만 회복 가능으로 보므로 401 poll은 즉시 치명 실패가 된다.
+
+### 훅을 놓을 위치: `resolveGrokCredential` + `grokFetchWithRetry` 확장 2단
+
+6곳 복제를 피하려면 두 층에 나눠 넣는 게 유일한 방법이다. 호출부는 `getGrokEndpoint`를 부르는 시점과 `fetch`를 부르는 시점이 분리돼 있어 한 층만으로는 커버가 안 된다.
+
+**층 1 — 사전 갱신 (`lib/grokRuntime.ts`의 `resolveGrokCredential`)**
+
+progrok의 `getValidBearer()`와 동일 규약. skew 2분, `~/.progrok/auth.json` 읽기 → 만료 임박 시 `https://auth.x.ai/oauth2/token`에 `grant_type=refresh_token` → 원자적 재기록. `routes/auth.ts:48-74`의 `saveGrokTokens`가 이미 temp+rename 원자 쓰기를 구현해 두었으므로 그대로 재사용한다. `routes/auth.ts:11-13`의 `GROK_CLIENT_ID` / `GROK_TOKEN_URL` 상수도 이미 존재한다.
+
+```ts
+// routes/auth.ts:11-13
+const GROK_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const GROK_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const GROK_TOKEN_URL = "https://auth.x.ai/oauth2/token";
+```
+
+이 층만으로 정상 케이스 100%가 커버된다. 각 호출부는 `getGrokEndpoint` 직전에 `await resolveGrokCredential(ctx, provider)` 한 줄을 추가할 뿐이고, 진입점은 이미 좁다: `grokExecution.ts` 4곳, `routes/video.ts:543`, `videoExtendI2vOperation.ts:68`, `routes/videoExtended.ts` 3곳, `agentPlannerModel.ts:115`, `promptBuilder/router.ts:107`.
+
+**층 2 — 사후 1회 재시도 (`lib/grokUpstreamRetry.ts`)**
+
+시계 오차나 서버측 조기 무효화로 실제 401이 오는 경우 대비. `grokFetchWithRetry`에 `onUnauthorized?: () => Promise<GrokCredential | null>` 옵션을 추가하고, 401 수신 시 정확히 1회만 갱신 후 `doFetch` 재실행한다. `doFetch`가 이미 replayable 계약(`:139-140` "MUST be replayable")이므로 구조 변경이 없다.
+
+단, `grokFetchWithRetry`를 쓰지 않는 두 호출은 별도 처리가 필요하다.
+
+- `lib/grokImageCore.ts:150-193` `postGrokImages` — `:144-148` 주석이 명시적으로 재시도를 금지한다. 401은 이미지가 생성되기 전 거부이므로 과금 위험이 없어 **401 한정 재시도는 안전**하다. 이 예외를 주석에 명기해야 한다.
+- `lib/grokVideoAdapter.ts:398-423` `startVideoRequest` — 동일 논리. `:401-403` 주석 참조.
+
+**커버리지 확인:** image(`postGrokImages`) / video-start(`startVideoRequest`) / video-poll(`pollVideoOnce` → `grokFetchWithRetry`) / video-download(`downloadVideo` → 인증 불필요, 층 무관) / planner(`planGrokImage`, `searchGrokVisualContext`, `planGrokVideo`, `requestGrokPlan` → 전부 `grokFetchWithRetry` 또는 단순 fetch). video-download는 서명 URL을 헤더 없이 받으므로 401 훅 대상이 아니다 (`lib/grokVideoDownload.ts:150-153`, Authorization 미설정).
+
+## 6. `routes/models.ts`의 grok 모델 목록 — registry-static
+
+**live 호출 아님.** 토큰이 필요 없다.
+
+```ts
+// routes/models.ts:163-176
+function grokLane(ctx: RuntimeContext, provider: "grok" | "grok-api" = "grok"): ModelLaneDto {
+  const state = grokLaneState(ctx);
+  return lane(state, {
+    image: ctx.config.grokProvider.defaultImageModel,
+    video: ctx.config.grokProvider.defaultVideoModel,
+  }, {
+    image: entries(provider, deriveModels(provider, "image")),
+    video: entries(
+      provider,
+      [...deriveModels("grok", "video")].filter((model) => model !== "grok-imagine-video-1.5-preview"),
+      videoCapabilities(),
+    ),
+  });
+}
+```
+
+`deriveModels`는 `lib/providers/derive.js`에서 registry(`lib/providers/registry.ts:74-80`)를 읽는 순수 함수이고, defaults는 config(`config.ts:405,410`)에서 온다. 네트워크가 없다.
+
+`grokApiLane`도 마찬가지로 `grokLane(ctx, "grok-api")`의 models를 그대로 재사용한다 (`routes/models.ts:182-183`).
+
+grok에서 **유일하게 live인 모델 목록**은 `/api/grok/status`다.
+
+```ts
+// routes/grok.ts:13-23
+      const r = await fetch(getGrokProxyUrl(ctx, "/v1/models"), {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (r.ok) {
+        const data: any = await r.json();
+        const models: string[] = data?.data?.map((m: any) => m.id).filter(Boolean) || [];
+        const hasImageModel = models.some((m: string) => m.startsWith("grok-imagine"));
+```
+
+여기는 현재 Authorization 헤더 없이 프록시에 붙어 progrok가 주입하는 방식이라, 직결 전환 시 **토큰이 필수**가 된다. 이 GET이 credential 유효성 프로브 역할까지 겸하게 되므로 §5의 401 훅이 여기에도 걸려야 한다. 참고로 registry의 `grok-api` credential에는 이미 동일 URL이 검증용으로 등록돼 있다 (`lib/providers/registry.ts:99` `validateUrl: "https://api.x.ai/v1/models"`).
+
+## 7. 테스트 계약에 박힌 프록시 가정
+
+diff 시 함께 깨지는 픽스처. 읽기만 했고 수정하지 않았다.
+
+- `tests/_videoExecutionFixture.ts:97` — `assert.equal(call.headers.get("authorization"), "Bearer dummy")`
+- `tests/videoRoute.test.ts:44`, `tests/videoExtendedRoute.test.ts:44`, `tests/video-download-cancellation.test.ts:48`, `tests/agent-mode-runtime-contract.test.ts:136` — 동일 단언
+- `tests/grok-execution-parity.test.ts:79-80,252,259-260` — grok은 `http://grok-fixture.invalid` + `Bearer dummy`, grok-api는 `https://api.x.ai` + 실키. 통합 후 이 parity 테스트는 "두 lane이 동일 origin/상이 bearer"로 재작성 대상
+- `tests/error-envelope-contract.test.ts:81,291` — `http://127.0.0.1:1` / `:9` 프록시 주소 가정
+- `tests/models-endpoint-contract.test.ts:104,121,366-383` — `grokProxyState` 주입으로 lane 상태 검증
+- `tests/prompt-builder-contract.test.ts:231,262` — grok-api는 이미 `https://api.x.ai/v1/chat/completions` 기대
+- `tests/grok-proxy-supervisor-contract.test.ts`, `tests/grok-proxy-restart.test.ts`, `tests/grok-proxy-launcher.test.ts` — supervisor 삭제 시 통째로 제거 대상
+- `tests/_executionRouteHarness.ts:164` — `grokUrl: "http://grok-fixture.invalid/v1"` 기본값
+
+## 8. 변경 규모 정리
+
+프록시 URL을 만드는 지점은 3개(`getGrokEndpoint`, `videoEndpoint`, `videoProxyUrl`)뿐이고 앞의 둘은 문자 단위로 동일하다. credential을 결정하는 분기는 `provider === "grok-api" ? ctx.xaiApiKey : undefined` 형태로 8곳에 복제돼 있다 (`grokExecution.ts` 27/59/84/96, `routes/video.ts:543`, `videoExtendI2vOperation.ts:68`, `promptBuilder/router.ts:107`, 그리고 인자 없이 프록시로 떨어지는 `agentPlannerModel.ts:115`). 이 8곳을 `resolveGrokCredential` 호출로 바꾸면 실행 경로 통합은 끝난다.
+
+부수적으로 사라지는 것은 프록시 supervisor 전체(`grokProxyLauncher.ts` 325줄), `trustedProxyOrigin` SSRF 예외 3곳, `grokUrl`/`grokPort`/`grokActualPort`/`grokProxyLive`/`grokProxy` ctx 필드 5개, `routes/videoExtended.ts:69`의 세 번째 엔드포인트 복제본이다.
+
+가장 주의할 지점은 `routes/videoExtended.ts`의 edit/extend-native/analyze 세 라우트다. 지금은 `directApiKey` 인자를 받는 통로조차 없어서 `grok-api` 사용자가 이 기능들을 쓰면 조용히 OAuth 프록시로 나간다. 통합은 이 잠재 버그를 자동으로 고치지만, 반대로 credential 배선을 빠뜨리면 세 라우트가 인증 없이 `api.x.ai`를 때리게 된다.
+
+

--- a/devlog/_plan/260909_grok_native_oauth/003_removal_blast_radius.md
+++ b/devlog/_plan/260909_grok_native_oauth/003_removal_blast_radius.md
@@ -1,0 +1,757 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, progrok, removal, blast-radius, research]
+---
+
+# 003 — progrok 제거 blast-radius 인벤토리 (opus-5 explorer, 2026-09-09)
+
+읽기 전용 조사 결과를 그대로 보존한다. 첫머리의 "핵심 판정"에 대한 답은
+000_plan.md에 있다: grok 레인은 폐기하지 않고 (b) 직접 호출로 재배선한다.
+
+# progrok 제거 blast-radius 인벤토리
+
+조사 기준: `/Users/jun/.codex/worktrees/6563/ima2-gen`, `dev` @ `11900764` (v3.15.1). 읽기 전용, 편집·커밋·빌드 없음.
+
+**핵심 판정 먼저**: `lib/grokRuntime.ts`는 삭제 대상이 아니다. 프록시 감독자(`grokProxyLauncher`)와 별개로 `grok` lane의 **모든 이미지/비디오 실행 경로**가 `getGrokProxyUrl()`로 엔드포인트를 만든다. progrok을 없애면 `grok` lane 자체가 죽고 `grok-api`(직접 키)만 남는다. 이게 이 인벤토리에서 가장 큰 정책 분기이며 wp4 착수 전에 확정되어야 한다.
+
+## 1. 프로덕션 코드
+
+### 1-1. lib/grokProxyLauncher.ts — 전체 삭제 (325줄)
+
+전량 progrok 자식 프로세스 감독자다. 외부에 노출되는 심볼 5개:
+
+```ts
+// lib/grokProxyLauncher.ts:43-50, 63-74, 80-86, 95-104, 110
+export type GrokProxyState = "stopped" | "gave-up-retryable" | "starting" | "ready" | "waiting-for-login" | "backoff" | "gave-up";
+export type GrokProbeToken = { readonly gen: number };
+export interface GrokProxyHandle { ... }
+export function restartPlan(attempt, opts): { delayMs; giveUp }
+export function isGrokProxyAuthRequiredMessage(line): boolean
+export function normalizeGrokProxyMessage(line): string
+export async function startGrokProxy(options): Promise<GrokProxyHandle>
+```
+
+실제 spawn 지점 (`lib/grokProxyLauncher.ts:176-182`):
+
+```ts
+const progrokBin = options.progrokBinPath ?? join(localBinPath(), isWin ? "progrok.cmd" : "progrok");
+const child = spawn(progrokBin, ["proxy", "--host", host, "--port", String(port)], {
+  stdio: ["ignore", "pipe", "pipe"], shell: isWin, windowsHide: true, env: process.env,
+});
+```
+
+`localBinPath()`는 `node_modules/.bin` (`lib/grokProxyLauncher.ts:106-108`) — 즉 번들 의존성 `progrok`의 bin shim에 직접 의존한다.
+
+**import하는 곳은 `server.ts:18`과 `lib/runtimeContext.ts:4` 둘뿐** (테스트 제외). 소비자 그래프가 좁아서 삭제 자체는 깨끗하다.
+
+### 1-2. lib/grokRuntime.ts — 삭제 아님, 축소/재작성 (27줄)
+
+```ts
+// lib/grokRuntime.ts:3-4, 10-18
+const DEFAULT_GROK_PROXY_HOST = "127.0.0.1";
+const DEFAULT_GROK_PROXY_PORT = 18645;
+
+export function getGrokProxyBaseUrl(ctx: RouteRuntimeContext = {}): string {
+  const grokCfg = (ctx.config as any)?.grokProvider || {};
+  const explicitUrl = (ctx as { grokUrl?: string }).grokUrl;
+  if (explicitUrl) return normalizeBaseUrl(explicitUrl);
+  const host = grokCfg.proxyHost || DEFAULT_GROK_PROXY_HOST;
+  const port = (ctx as { grokActualPort?: number }).grokActualPort || grokCfg.proxyPort || DEFAULT_GROK_PROXY_PORT;
+  return `http://${host}:${port}`;
+}
+```
+
+소비자 7곳이 프로덕션 실행 경로다:
+
+| 소비자 | 라인 | 역할 |
+|---|---|---|
+| `lib/grokImageCore.ts` | 4, 71 | `getGrokEndpoint()` 프록시 분기 |
+| `lib/grokVideoShared.ts` | 13, 122 | `videoEndpoint()` 프록시 분기 |
+| `routes/videoExtended.ts` | 7, 70 | 영상 연장 엔드포인트 |
+| `routes/grok.ts` | 3, 13, 22 | `/api/grok/status` 프로브 |
+| `lib/providers/adapters/grokOperations.ts` | 5, 60, 93 | 어댑터 origin |
+| `lib/providers/adapters/grokMultimodeOperations.ts` | 11, 103 | 멀티모드 origin |
+
+`getGrokDirectBaseUrl()` (`lib/grokRuntime.ts:25-27`)는 `https://api.x.ai`를 반환하며 progrok과 무관하다 — 유지.
+
+프록시/직접 분기 구조는 이미 `directApiKey` 인자로 되어 있다 (`lib/grokImageCore.ts:62-73`):
+
+```ts
+export function getGrokEndpoint(ctx, path = "/v1/images/generations", directApiKey?: string) {
+  if (directApiKey) {
+    return { url: `https://api.x.ai${normalizedPath}`, headers: { ..., Authorization: `Bearer ${directApiKey}` } };
+  }
+  return { url: getGrokProxyUrl(ctx, path), headers: { ..., Authorization: "Bearer dummy" } };
+}
+```
+
+`videoEndpoint()`도 동일 구조 (`lib/grokVideoShared.ts:113-125`). 즉 **wp4의 실질 작업은 `directApiKey` 없는 경로를 어떻게 처리하느냐**다. 선택지는 두 개뿐이고, wp4 diff 규모가 여기서 갈린다.
+
+- (a) `grok` lane 폐기 → `grok-api`만 유지. `lib/providers/registry.ts:70-88`의 lane 정의, `routes/models.ts:327` 등록, 프로바이더 enum 파생 전부 연쇄.
+- (b) `grok` lane을 직접 호출로 재배선 → `getGrokProxyUrl` 호출부 6개를 `api.x.ai` + 키 해석으로 치환, `grokRuntime.ts`는 `getGrokDirectBaseUrl`만 남기고 축소.
+
+### 1-3. server.ts — 부분 수정 (612줄)
+
+`rg -n 'startGrokProxy|grokChild|grokProxy|markGrokProxyPort|grokProxyLive|advertise'` 결과별 처리:
+
+**삭제할 블록 — 감독자 부팅 (`server.ts:491-515`)**
+
+```ts
+const grokChild = ctx.config.grokProvider.autoStart
+  ? await startGrokProxy({
+      host: ctx.config.grokProvider.proxyHost,
+      port: ctx.config.grokProvider.proxyPort,
+      restartDelayMs: ctx.config.grokProvider.restartDelayMs,
+      onPortSelected: ({ url, port }) => {
+        ctx.markGrokProxyPort({ url, port });
+        ctx.grokProxyLive = false;   // Port selection is an intent to bind, not a successful bind.
+        advertise(ctx);
+      },
+      onReady: ({ url, port }) => { ctx.markGrokProxyPort({ url, port }); ctx.grokProxyLive = true; advertise(ctx); },
+      onExit: () => { ctx.grokProxyLive = false; advertise(ctx); },
+    })
+  : null;
+ctx.grokProxy = grokChild ?? undefined;
+```
+
+**삭제 — import (`server.ts:18`)**, **타입 (`server.ts:46`)**:
+
+```ts
+import { startGrokProxy } from "./lib/grokProxyLauncher.js";
+markGrokProxyPort: (info?: { url?: string; port?: number }) => void;
+```
+
+**삭제 — 부트 컨텍스트 필드 (`server.ts:390`, `401-403`)**:
+
+```ts
+const grokPort = config.grokProvider.proxyPort;
+grokPort,
+grokActualPort: grokPort,
+grokUrl: `http://${config.grokProvider.proxyHost}:${grokPort}/v1`,
+```
+
+**삭제 — 마커 (`server.ts:435-439`)**:
+
+```ts
+markGrokProxyPort: ({ url, port }: { url?: string; port?: number } = {}) => {
+  if (port) ctx.grokActualPort = port;
+  if (url) ctx.grokUrl = url;
+  else if (port) ctx.grokUrl = `http://${ctx.config.grokProvider.proxyHost}:${port}/v1`;
+},
+```
+
+**수정 — 셧다운 (`server.ts:525-526`)** 두 줄 제거, `oauthChild` 라인(523-524)은 유지:
+
+```ts
+try { grokChild?.stop?.(); } catch {}
+try { grokChild?.kill?.(); } catch {}
+```
+
+**수정 — 부팅 로그 (`server.ts:555`)**, Grok 프록시 포트 문구 삭제:
+
+```ts
+console.log(`Provider policy: GPT OAuth, API-key Responses, and Grok Images providers. GPT OAuth proxy port ${ctx.oauthPort}; Grok proxy port ${ctx.grokActualPort || ctx.grokPort}.`);
+```
+
+**남는 것**: `advertise()`(335-356), `unadvertise()`(358-364), 호출부 `server.ts:484`(OAuth ready), `556`(listen 후), `539`(exit 훅)은 전부 유지. `advertise` 자체는 progrok과 무관한 서버 광고 메커니즘이다.
+
+### 1-4. advertise() 및 ~/.ima2/server.json 스키마
+
+`buildAdvertisePayload()` (`server.ts:306-333`) — 발행 필드 전체:
+
+```ts
+export function buildAdvertisePayload(ctx: RuntimeContext) {
+  const grokLive = ctx.grokProxyLive === true;
+  return {
+    port, url, pid: process.pid, startedAt, version, adminNonce,
+    backend: { configuredPort, actualPort, url },
+    oauth:   { configuredPort, actualPort, url, status: ctx.oauthReadyState },
+    grok: {
+      configuredPort: Number(ctx.grokPort),
+      actualPort: grokLive ? Number(ctx.grokActualPort || ctx.grokPort) : null,
+      url: grokLive ? ctx.grokUrl : null,
+      live: grokLive,
+    },
+  };
+}
+```
+
+파일 쓰기는 `server.ts:335-356`, 0o600 강제 + `chmodSync` 재확인. `adminNonce`가 kill-switch credential이라 권한 로직은 건드리지 않는다.
+
+**`grok` 섹션을 읽는 소비자는 정확히 한 곳**:
+
+```ts
+// bin/commands/service.ts:139-151
+const grok = (entry as { grok?: { live?: boolean } }).grok;
+// grok.live only exists in the advertise payload, not /api/health (audit note).
+if (grok && grok.live === false) {
+  console.log("  Warning: Grok proxy is not live under the service environment.");
+  console.log("  If Grok worked in a terminal, the service PATH may be missing its binary.");
+}
+```
+
+ComfyUI 브리지는 `backend`/`url`/`port`만 읽고 grok은 보지 않는다 (`integrations/comfyui/ima2_gen_bridge/nodes.py:93-101`). `bin/lib/client.ts:114`, `bin/ima2.ts:82-91`, `bin/commands/stop.ts:14-17`도 pid/url만 사용. **payload의 `grok` 키를 통째로 없애도 파손되는 외부 소비자는 `service.ts`의 경고문 하나뿐**이다.
+
+`routes/health.ts:20-23`은 별도 표면이고 advertise와 다른 계약이다:
+
+```ts
+grok: {
+  configuredPort: Number(ctx.grokPort),
+  actualPort: Number(ctx.grokActualPort || ctx.grokPort),
+  url: ctx.grokUrl,
+},
+```
+
+### 1-5. lib/runtimeContext.ts — 필드 5개 + 기본값 제거
+
+인터페이스 (`lib/runtimeContext.ts:22-28`):
+
+```ts
+grokActualPort: number | undefined;
+grokPort: number;
+grokUrl: string;
+/** Supervisor handle. Optional: absent when autoStart is off or in test contexts. */
+grokProxy?: GrokProxyHandle | undefined;
+/** True only while a supervised child is actually listening. */
+grokProxyLive?: boolean | undefined;
+```
+
+import (`lib/runtimeContext.ts:4`): `import type { GrokProxyHandle } from "./grokProxyLauncher.js";`
+
+`requireRuntimeContext()` 기본값 (`lib/runtimeContext.ts:116-124`):
+
+```ts
+if (target.grokPort === undefined) {
+  target.grokPort = (target.config as AppConfig).grokProvider?.proxyPort ?? 18645;
+}
+if (target.grokUrl === undefined) {
+  const grokCfg = (target.config as AppConfig).grokProvider;
+  const host = grokCfg?.proxyHost ?? "127.0.0.1";
+  const port = target.grokActualPort ?? target.grokPort ?? grokCfg?.proxyPort ?? 18645;
+  target.grokUrl = `http://${host}:${port}/v1`;
+}
+```
+
+`createTestRuntimeContext()` (`lib/runtimeContext.ts:197-199`):
+
+```ts
+grokActualPort: undefined,
+grokPort: 18645,
+grokUrl: "http://127.0.0.1:18645/v1",
+```
+
+주석 하나가 `advertise()` 재실행 계약을 언급하니 문구도 손봐야 한다 (`lib/runtimeContext.ts:16-19`): `"(advertise() re-runs on proxy state changes and must not rotate it)"` — 프록시 상태 변화가 사라지면 이 근거가 무효.
+
+### 1-6. config.ts:378-387 — 키별 판정
+
+| 키 | env | 기본값 | 읽는 곳 | 판정 |
+|---|---|---|---|---|
+| `proxyPort` | `IMA2_GROK_PROXY_PORT` | `18645` | `server.ts:390`, `grokProxyLauncher.ts:112`, `grokRuntime.ts:16`, `runtimeContext.ts:117,122`, `registry.ts:73` | 삭제 (lane 폐기 시) |
+| `proxyHost` | `IMA2_GROK_PROXY_HOST` | `127.0.0.1` | `server.ts:403,438`, `grokProxyLauncher.ts:111`, `grokRuntime.ts:15`, `runtimeContext.ts:121`, `registry.ts:73` | 삭제 |
+| `autoStart` | `IMA2_NO_GROK_PROXY` (부정) | `true` | `server.ts:491` 단 한 곳 | 삭제 |
+| `restartDelayMs` | `IMA2_GROK_RESTART_DELAY_MS` | `2000` | `grokProxyLauncher.ts:113`, `server.ts:494` | 삭제 |
+| `restartMaxAttempts` | `IMA2_GROK_RESTART_MAX_ATTEMPTS` | `6` | `grokProxyLauncher.ts:114` | 삭제 |
+| `restartMaxDelayMs` | `IMA2_GROK_RESTART_MAX_DELAY_MS` | `60_000` | `grokProxyLauncher.ts:115` | 삭제 |
+| `restartHealthyMs` | `IMA2_GROK_RESTART_HEALTHY_MS` | `60_000` | `grokProxyLauncher.ts:116` | 삭제 |
+
+`config.ts:388` 이후 (`plannerModel`, 타임아웃, `defaultImageModel`, 비디오 예산 등)는 전부 유지 — 프록시가 아니라 xAI 호출 예산이다.
+
+`lib/providers/registry.ts:73`이 삭제 대상 env 두 개를 lane credential로 선언한다:
+
+```ts
+credentials: [{ kind: "oauth-proxy", envVars: ["IMA2_GROK_PROXY_HOST", "IMA2_GROK_PROXY_PORT"], configKey: "grokProvider" }],
+```
+
+registry는 생성 파일 게이트가 걸려 있다 (`scripts/generate-provider-types.mjs --check`, ci.yml:63-64 / pr-fast.yml:51-52). 여기를 고치면 생성물 재생성이 필수.
+
+### 1-7. lib/runtimePorts.ts — 유지 (삭제 금지)
+
+`findAvailablePort`는 progrok 런처가 유일한 프로덕션 소비자다 (`lib/grokProxyLauncher.ts:6,156`). 하지만 **모듈은 유지**해야 한다:
+
+```
+server.ts:30       import { getServerPort, listenWithPortFallback } from "./lib/runtimePorts.js";
+lib/oauthLauncher.ts:2  import { parseLocalhostPortFromUrl, parseOAuthReadyUrl } from "./runtimePorts.js";
+tests/history-tombstone.test.ts:14,40   findAvailablePort
+tests/runtime-ports.test.ts:6-10        5개 심볼 전부
+```
+
+`findAvailablePort` 자체는 OAuth가 쓰지 않는다 — OAuth는 `parseOAuthReadyUrl`/`parseLocalhostPortFromUrl`만 쓴다. 즉 progrok 제거 후 `findAvailablePort`의 프로덕션 소비자는 0이 되고 테스트 2개만 남는다. export 유지가 가장 저비용(테스트 수정 불필요), 삭제하려면 `tests/history-tombstone.test.ts`와 `tests/runtime-ports.test.ts`를 같이 손봐야 한다.
+
+### 1-8. bin/commands/grok.ts — 전체 삭제 (90줄)
+
+HELP 텍스트 (`bin/commands/grok.ts:9-26`)가 전부 progrok 계약이다:
+
+```
+  Manage the bundled progrok runtime used by the Grok image provider.
+  No separate progrok install is required.
+  Subcommands: login / logout / status / models / proxy
+  Notes:
+    ima2 serve auto-starts the bundled proxy on 127.0.0.1:18645 by default.
+    Use IMA2_NO_GROK_PROXY=1 to disable automatic proxy startup.
+```
+
+passthrough 구조 — 서브커맨드 화이트리스트가 없다. `argv`를 그대로 progrok 바이너리에 넘긴다 (`bin/commands/grok.ts:35-48, 73`):
+
+```ts
+const progrokBin = join(localBinPath(), isWin ? "progrok.cmd" : "progrok");
+const child = spawn(progrokBin, argv, { cwd: ROOT, env, stdio: "inherit", shell: isWin, windowsHide: true });
+...
+const code = await spawnProgrok(argv, env);
+```
+
+`env.PATH`에 `node_modules/.bin`을 prepend한다 (`bin/commands/grok.ts:65-68`). export된 `normalizeGrokLoginArgs` (`bin/commands/grok.ts:50-56`)는 `tests/grok-command-login-contract.test.ts`가 직접 import한다.
+
+`ima2 grok --help`는 CI 스모크에 걸려 있다 (아래 5절) — 커맨드를 지우면 워크플로도 같이 고쳐야 한다.
+
+### 1-9. doctor 계열
+
+`bin/lib/doctor-runtime.ts:7` — 런타임 의존성 존재 검증 목록:
+
+```ts
+const RUNTIME_DEPENDENCIES = ["express", "better-sqlite3", "openai", "openai-oauth", "progrok/package.json", "@openai/codex/package.json", "zod"];
+```
+
+`"progrok/package.json"` 항목 제거 필요.
+
+`bin/lib/doctor-providers.ts:49-55` — 자격증명 파일 탐지:
+
+```ts
+if (lane === "grok") {
+  const files = [join(home, ".progrok", "auth.json"), join(home, ".grok", "auth.json")];
+  ...
+  return { code: "CREDENTIAL_MISSING", lane, kind: "warn", text: `${lane}: no ~/.progrok or ~/.grok auth file` };
+}
+```
+
+`~/.progrok` 경로와 경고 문구를 정리. `bin/commands/doctor.ts`에는 `grok` 매치가 없다 — advertise 파일 읽기(163, 293-297)만 있고 grok 필드는 안 본다.
+
+### 1-10. routes/auth.ts:258 — notifyCredentialsChanged 대체
+
+```ts
+const result = provider === "grok"
+  ? await startGrokDeviceCode(() => ctx?.grokProxy?.notifyCredentialsChanged())
+  : await startCodexDeviceCode();
+```
+
+이 콜백은 로그인 성공 시 `waiting-for-login` 상태의 감독자를 재기동시키는 유일한 입구다 (`lib/grokProxyLauncher.ts:285-293`). 감독자가 사라지면 **재기동할 대상 자체가 없으므로 대체 로직이 필요 없다** — 콜백 인자를 제거하고 `startGrokDeviceCode()`를 무인자 호출로 바꾸면 된다. `startGrokDeviceCode`의 시그니처가 콜백을 옵셔널로 받는지 확인 후 정리.
+
+### 1-11. routes/models.ts — grokLaneState 재작성
+
+`routes/models.ts:140-161`이 감독자 상태 7종을 lane 상태로 접는다:
+
+```ts
+function grokLaneState(ctx: RuntimeContext): LaneState {
+  if (!ctx.grokUrl) return { status: "disconnected", reason: "Grok proxy not configured" };
+  switch (ctx.grokProxy?.state) {
+    case "ready": return { status: "ready" };
+    case "starting": return { status: "ready", reason: UNPROBED_GROK_REASON };
+    case "backoff": return { status: "disconnected", reason: "Grok proxy restarting" };
+    case "gave-up-retryable": return { status: "ready", reason: UNPROBED_GROK_REASON };
+    case "waiting-for-login": return { status: "disconnected", reason: "Grok login required" };
+    case "gave-up": return { status: "disconnected", reason: "Grok proxy failed to start" };
+    case "stopped": return { status: "disconnected", reason: "Grok proxy stopped" };
+    default: return { status: "ready", reason: UNPROBED_GROK_REASON };
+  }
+}
+```
+
+`UNPROBED_GROK_REASON = "configured proxy endpoint; live session not probed"` (`routes/models.ts:130`)도 문구 정리 대상.
+
+### 1-12. routes/grok.ts — 전체 재작성 또는 삭제 (33줄)
+
+`/api/grok/status`가 프록시 `/v1/models`를 프로브하고 세대 토큰으로 감독자를 승격시킨다 (`routes/grok.ts:11, 13, 22, 25, 30`). progrok 제거 시 이 라우트는 존재 이유가 사라진다. UI가 10초 폴링하는 표면이라 (`routes/grok.ts:27-29` 주석) 프론트 연동 확인 필요.
+
+### 1-13. routes/quota.ts:118-127 — progrok:auth-json 라벨
+
+```ts
+const auth = JSON.parse(readFileSync(join(homeDir, ".progrok", "auth.json"), "utf8")) as { accessToken?: string };
+...
+source: "progrok:auth-json",
+```
+
+`~/.grok/auth.json` 경로(105-112, source `grok:auth-json` / `grok:auth-json-oidc`)는 progrok과 무관하게 xAI CLI 자격증명이므로 유지. `~/.progrok` 후보만 제거.
+
+### 1-14. 패키징 · 인프라
+
+| 파일 | 라인 | 내용 | 처리 |
+|---|---|---|---|
+| `package.json` | 102 | `"progrok": "file:vendor/progrok-0.2.0.tgz"` | 삭제 |
+| `package.json` | 112 | `bundleDependencies` 내 `"progrok"` | 삭제 |
+| `package.json` | 79 | `files` 내 `"vendor/"` | 유지 (openai-oauth tgz 잔존) |
+| `package.json` | 32 | `lint:pkg`의 `mustInclude` 배열에 `'vendor/'` | 유지 |
+| `package-lock.json` | — | `node_modules/progrok` 엔트리 + 루트 `bundleDependencies` | 재생성 필요 |
+| `vendor/progrok-0.2.0.tgz` | — | 번들 tarball | 삭제 |
+| `nix/node-modules.nix` | 21, 29-30 | `rootLock.packages."node_modules/progrok"` 직접 참조 | 삭제 (이 코드가 없으면 nix eval 실패 가능) |
+| `flake.nix` | 18 | 주석 "vendored progrok tarball" | 문구 수정 |
+| `Dockerfile` | 12 | 주석 "(openai-oauth, progrok) referenced by package.json" | 문구 수정 |
+| `scripts/qa-grok-video.mjs` | 11, 181 | progrok 전제 안내 문구 | 수정 |
+| `scripts/paired-generated-paths.txt` | 9 | `lib/grokProxyLauncher.js` | 삭제 |
+| `scripts/lib/uiBuildReceiptFiles.mjs` | 25 | `\.progrok` 시크릿 정규식 | 유지 (방어적) |
+
+`docker-compose.yml`은 `progrok` 매치 없음. `nix/node-modules.nix:21` 주석은 `file:vendor/progrok-0.1.1.tgz`라고 적혀 있어 실제 `0.2.0`과 이미 어긋나 있다.
+
+`scripts/check-install-policy.mjs:67-71`이 manifest와 lock의 `bundleDependencies` 일치를 강제하므로, package.json만 고치고 lock을 재생성하지 않으면 CI가 잡는다:
+
+```js
+const manifestBundles = [...(manifest.bundleDependencies || [])].sort();
+const lockBundles = [...(lock.packages?.[""]?.bundleDependencies || [])].sort();
+... `bundleDependencies mismatch: package.json=${manifestBundles.join(",")} package-lock.json=${lockBundles.join(",")}`
+```
+
+`scripts/release-contract.mjs:458, 471`도 `bundleDependencies`를 순회한다.
+
+## 2. 테스트
+
+### 2-1. 파일별 판정
+
+| 파일 | 줄 | 히트 | 내용 | 판정 |
+|---|---|---|---|---|
+| `tests/grok-proxy-supervisor-contract.test.ts` | 142 | 19 | 로그인 재기동, `waiting-for-login` 비-spawnable, 세대 토큰. 가짜 progrok 스크립트를 tmpdir에 씀 | **DELETE** |
+| `tests/grok-proxy-restart.test.ts` | 53 | 12 | `restartPlan` 지수 백오프 + 예산 소진, 없는 바이너리 재시도 | **DELETE** |
+| `tests/grok-proxy-launcher.test.ts` | 72 | 8 | `startGrokProxy`, auth 메시지 정규화(`progrok login` → `ima2 grok login`) | **DELETE** |
+| `tests/grok-advertise-liveness-contract.test.ts` | 51 | 7 | `buildAdvertisePayload`의 grok liveness 4케이스 | **DELETE** — 단, `backend` 계약 검증(42-50)은 별도 테스트로 보존 권장 |
+| `tests/grok-command-login-contract.test.ts` | 30 | 1 | `normalizeGrokLoginArgs` 4케이스 | **DELETE** (`bin/commands/grok.ts` 동반 삭제 시) |
+| `tests/models-endpoint-contract.test.ts` | 460 | 6 | `grokProxyState` 주입으로 lane 상태 매핑 검증 (104, 114, 121, 366, 377, 383) | **REWRITE** — lane 상태 계약이 바뀌므로 |
+| `tests/runtime-context-normalize.test.ts` | 67 | 4 | `grokUrl` 기본값·오버라이드 (25, 62-65) | **KEEP-with-edit** — grok 단정 제거 |
+| `tests/package-install-smoke.mjs` | 354 | 6 | 번들 목록(141), bin shim 존재(154), `progrok --help` 실행(184, 238-239), `bundled progrok runtime` 매치(223), `IMA2_NO_GROK_PROXY=1`(218) | **REWRITE** |
+| `tests/release-pipeline-contract.test.ts` | 766 | 2 | `validateBundleParity`가 `["progrok", "openai-oauth"]` 사용 (215, 218) | **KEEP-with-edit** — 픽스처 문자열 교체 |
+| `tests/cli-commands.test.js` | 367 | 2 | `ima2 grok --help`가 `bundled progrok runtime`, `IMA2_NO_GROK_PROXY=1` 출력 (357-365) | **REWRITE or DELETE** |
+| `tests/agent-mode-runtime-contract.test.ts` | 802 | 4 | `proxyPort: 18645` 픽스처 + origin 단정 (101, 135, 514, 603) | **KEEP-with-edit** |
+| `tests/e2e-app-environment.test.ts` | — | — | `IMA2_NO_GROK_PROXY`, `IMA2_GROK_PROXY_PORT/HOST` env 계약 (36-39, 66) | **KEEP-with-edit** |
+| `tests/j6-isolation-preflight.test.mjs` | 234 | 1 | 포트 18645 격리(99), `IMA2_NO_GROK_PROXY` 단정(222) | **KEEP-with-edit** |
+| `tests/history-tombstone.test.ts` | — | — | `findAvailablePort` 사용(14, 40), `IMA2_NO_GROK_PROXY: "1"`(69) | **KEEP-with-edit** |
+| `tests/grok-planner-adapter.test.ts` | 344 | 2 | 플래너 로직 — 프록시와 무관 | **KEEP** (URL 픽스처만 확인) |
+| `tests/grok-execution-parity.test.ts` | 392 | 1 | 실행 패리티 | **KEEP** |
+| `tests/grokVideoAdapter.test.ts` / `grokVideoPlannerFallback.test.ts` / `videoRoute.test.ts` / `videoExtendI2v.test.ts` / `prompt-builder-contract.test.ts` / `video-download-cancellation.test.ts` / `_executionRouteHarness.ts` | — | 각 1-2 | URL 픽스처 수준 | **KEEP-with-edit** |
+
+E2E 픽스처도 같은 env를 쓴다: `ui/e2e/fixtures/appIsolation.ts:32-33`, `ui/e2e/fixtures/appServer.ts:79, 138-139, 318`, `ui/e2e/fixture-isolation.spec.ts:34`. `appServer.ts:318`의 `grokProvider: { disableAutoStart: true }`는 config 키가 사라지면 무의미해진다.
+
+### 2-2. 삭제를 등록하는 방법
+
+러너는 디렉터리 스캔이라 등록이 필요 없다 (`scripts/run-tests.mjs:8-11`):
+
+```js
+const files = readdirSync(testDir)
+  .filter((f) => /\.test\.[cm]?[jt]s$/.test(f))
+  .map((f) => join(testDir, f)).sort();
+```
+
+**하지만 인벤토리 문서는 생성물이고 CI가 drift를 잡는다.** `scripts/classify-tests.mjs`는 `--check`일 때 온디스크 파일과 재생성 결과가 **문자열 동일**해야 통과한다 (56-63):
+
+```js
+if (check) {
+  const existing = existsSync(outPath) ? readFileSync(outPath, "utf8").replace(/\r\n/g, "\n") : null;
+  if (existing !== output) {
+    console.error(`${outPath} is stale. Run: node scripts/classify-tests.mjs`);
+    process.exit(1);
+  }
+}
+```
+
+총계 줄(`Total: N (runtime: R, contract: C)`)까지 포함해 비교하므로, 테스트 파일을 하나라도 지우면 `docs/migration/runtime-test-inventory.md`(503줄)를 반드시 재생성해야 한다. 절차: `node scripts/classify-tests.mjs` (플래그 없이) 실행 → 파일 재작성 → 커밋. 삭제 대상 5개는 인벤토리 89-91, 81-82행에 등재돼 있다.
+
+`npm run test:inventory`는 `--check --fail-js-runtime`이며 (`package.json:26`), CI 두 곳에서 돈다.
+
+### 2-3. structure/01 라인수 게이트
+
+`scripts/refresh-structure-line-counts.mjs`가 표 셀을 정규식으로 파싱한다 (37):
+
+```js
+const ROW_RE = /\| `([^`]+\.(?:ts|tsx))` \| (\d+|n\/a) \|/g;
+```
+
+삭제된 파일 처리는 **조용한 무시**다 (26-30, 45-47):
+
+```js
+function lineCount(relPath) {
+  const abs = join(root, relPath);
+  if (!existsSync(abs)) return null;   // ← 파일이 없으면 null
+  ...
+}
+const actual = lineCount(relPath);
+if (actual == null) return full;        // ← 행을 그대로 둠, drift로 잡지 않음
+```
+
+즉 `lib/grokProxyLauncher.ts`를 지워도 `structure/01-file-function-map.md:292`의 `| lib/grokProxyLauncher.ts | 326 | ... |` 행은 **게이트를 통과한 채 유령으로 남는다**. wp5에서 수동 삭제해야 한다. 대상 행:
+
+```
+structure/01-file-function-map.md:292  | `lib/grokProxyLauncher.ts` | 326 | Grok proxy process startup and readiness helpers |
+structure/01-file-function-map.md:293  | `lib/grokRuntime.ts` | 28 | Grok runtime configuration helpers |
+structure/01-file-function-map.md:137  | `bin/commands/grok.ts` | 91 | Grok OAuth login and status helpers |
+structure/01-file-function-map.md:68   grok.ts               GET /api/grok/status + progrok helpers
+```
+
+반대로 `server.ts`, `config.ts`, `lib/runtimeContext.ts`, `routes/models.ts`는 줄 수가 줄어들면 drift로 **잡힌다** (SCOPES에 포함, 15-24). `node scripts/refresh-structure-line-counts.mjs` 실행 필요. 이 게이트는 pr-fast.yml:49-50과 ci.yml:57-58 양쪽에서 fast-fail로 돈다.
+
+## 3. 문서 / SoT
+
+### 3-1. 파일별 히트 수
+
+`rg -c 'progrok|18645|grok proxy|Grok proxy|IMA2_GROK_PROXY|IMA2_NO_GROK_PROXY'`:
+
+```
+structure/06-infra-operations.md            7
+docs/API.zh-TW.md / API.zh-CN.md            7 / 7
+docs/API.md                                 6
+docs/grok-video-i2v-plan.{md,zh-CN,zh-TW}   5 each
+docs/README.{ko,zh-CN,zh-TW}.md             5 each
+docs/CLI.{md,zh-CN,zh-TW}.md                5 each
+README.md                                   5
+structure/02-command-reference.md           4
+structure/00-structure-hub.md               4
+site/src/i18n/strings.ts                    4
+site/.../reference/config.astro (en+ko)     3 each
+structure/01-file-function-map.md           2
+site/.../api|providers|architecture.astro   2 each (en+ko)
+skills/ima2/SKILL.md                        1
+site/.../cli.astro, docs/index.astro        1 each (en+ko)
+docs/grok-video-i2v-research.*              1 each
+AGENTS.md                                   1
+```
+
+`CONTRIBUTING.md`, `devlog/_plan/README.md`는 매치 없음.
+
+### 3-2. structure/*.md — wp5가 다시 쓸 SoT 섹션
+
+**`structure/06-infra-operations.md`** (가장 무겁다):
+
+- `:61` — Mermaid 프로세스 다이어그램 노드 `SRV --> GROK["progrok<br/>default port 18645"]`
+- `:77` — 표 행 `| bundled dependencies | progrok, patched openai-oauth, zod |`
+- `:168-170` — 환경변수 표 3행 (`IMA2_GROK_PROXY_HOST` / `_PORT` / `IMA2_NO_GROK_PROXY`)
+- `:213` — 프로바이더 산문 단락, `provider: "grok"` uses bundled progrok
+- `:374` — 2026-06-01 변경 이력 항목 (progrok-backed video)
+
+**`structure/00-structure-hub.md`**:
+
+- `:13` — `lib/*` 소유 범위 산문 "Grok/progrok provider plumbing"
+- `:21` — 2026-05-30 스냅샷 노트 "The Grok provider path now bundles progrok"
+- `:38` — 2026-08-23 comfy 스냅샷, "what distinguishes it from the grok/progrok lane" (comfy lane 정의가 progrok 대조에 의존)
+- `:59` — Mermaid `API --> GROK["progrok<br/>xAI proxy"]`
+
+**`structure/02-command-reference.md`**:
+
+- `:58` — 커맨드 표 행 `| ima2 grok login/status/models/proxy | ... | bin/commands/grok.ts, routes/grok.ts |`
+- `:134`, `:192` — `--provider` 플래그 설명 2곳 ("`grok` uses bundled progrok OAuth")
+- `:143` — 프로바이더 오버라이드 의미론 산문
+
+**`structure/01-file-function-map.md`**: 위 2-3절의 4행.
+
+### 3-3. 사용자 문서
+
+- `README.md:173-174` (프로바이더 설명), `:355-357` (env 표 3행)
+- `docs/CLI.md:18` (커맨드 표), `:116` (프로바이더 설명), `:165-168` (자동 시작 안내 단락), `:468` (`ima2 grok status` 행)
+- `docs/API.md:65`, `:155` (`GET /api/grok/status`), `:166` (`~/.progrok/auth.json`), `:397`, `:882-883` (에러 코드 `GROK_RATE_LIMITED` / `GROK_AUTH_FAILED` 설명)
+- `docs/README.ko.md:135-136`, `:266-268`
+- 중국어 번역본 6종(`API`/`CLI`/`README` × `zh-CN`/`zh-TW`)이 원문과 1:1 대응 — 동일 위치 동반 수정
+- `docs/grok-video-i2v-{plan,research}.*` 9파일 — 과거 계획 문서, 수정 대신 그대로 두는 판단도 가능
+- `skills/ima2/SKILL.md:88` — "Use Grok when the request should run through bundled progrok"
+- `AGENTS.md:28` — `- Grok: bundled progrok (xAI Images API)`
+
+### 3-4. site/ (Astro)
+
+`site/`는 Astro 정적 사이트이고 GitHub Pages로 배포된다. 영문/한국어 페이지가 쌍으로 존재:
+
+```
+site/src/pages/docs/reference/config.astro:45-47        (+ ko 동일)
+site/src/pages/docs/concepts/architecture.astro         2건 (+ ko)
+site/src/pages/docs/concepts/providers.astro            2건 (+ ko)
+site/src/pages/docs/reference/api.astro                 2건 (+ ko)
+site/src/pages/docs/reference/cli.astro                 1건 (+ ko)
+site/src/pages/docs/index.astro                         1건 (+ ko)
+site/src/i18n/strings.ts                                4건
+```
+
+`config.astro:45-47`은 env 표 `<tr>` 3행으로, README/structure 표와 같은 내용이다. 한국어 페이지도 동일 라인 번호.
+
+## 4. 선행 유닛 `260819c_grok_proxy_supervision/`
+
+### 4-1. 계획한 것
+
+README 기준 (`devlog/_plan/260819c_grok_proxy_supervision/README.md`), GUI 로그인 후에도 Grok이 `Disconnected`로 남는 문제를 3개 WP로 나눴다:
+
+| 문서 | 줄 | 내용 |
+|---|---|---|
+| `000_research.md` | 149 | 결함 3종 실측 재현과 근본 원인 |
+| `001_opencodex.md` | 113 | opencodex 감독 구조 대조 |
+| `010_wp2_supervisor.md` | 274 | WP2 감독자 도입 + 로그인 재기동 |
+| `020_wp3_advertise.md` | 135 | WP3 advertise가 죽은 포트를 광고하지 않음 |
+| `030_wp4_lane.md` | 110 | WP4 lane 상태를 감독자 상태와 일치 |
+
+명시된 결함 3종:
+
+```
+1. 인증 실패가 종착 상태다. progrok은 로그인 없으면 exit(1)하고
+   (progrok/src/commands/proxy.ts:22-26), 런처는 그때 재시작을 포기한다.
+2. advertise 파일이 죽은 포트를 광고한다.
+3. lane 상태가 전송 상태와 무관하다. URL 문자열만 있으면 ready
+   (routes/models.ts:119-124).
+```
+
+적대적 감사 4라운드(FAIL→FAIL→FAIL→PASS) 기록도 있다.
+
+### 4-2. 실제로 구현된 것
+
+`devlog/_plan/README.md:26`는 이 유닛을 **"조사 + 로드맵 완료 (000-030), 구현 미착수"**로 적어놓았다. 그러나 코드는 다르다:
+
+```
+git log --oneline --since=2026-08-19 -- lib/grokProxyLauncher.ts
+054c729f 2026-08-19 fix(grok): make GUI login revive the progrok proxy without a server restart
+```
+
+이 커밋 하나가 **WP2/WP3/WP4를 전부 실현했다**. 현재 코드에 남은 증거:
+
+- WP2: `GrokProxyState` 7상태 + `waiting-for-login` 분리 + `notifyCredentialsChanged` (`lib/grokProxyLauncher.ts:43-56, 285-293`)
+- WP3: `grokProxyLive` + `buildAdvertisePayload`의 liveness 게이트 (`server.ts:307, 326-332`), `tests/grok-advertise-liveness-contract.test.ts`
+- WP4: `grokLaneState`가 `ctx.grokProxy?.state`를 switch (`routes/models.ts:140-161`)
+
+즉 `_plan/README.md:26`의 "구현 미착수" 서술은 **부정확**하다. 아카이빙 시 이 오기를 함께 정정해야 한다.
+
+### 4-3. 아카이빙 절차
+
+`devlog/_plan/README.md:10-12`가 규칙을 정한다:
+
+```
+`_plan`은 앞으로 구현하거나 검증할 일이 남은 항목만 둔다. 구현 근거와
+테스트가 확인된 항목은 `_fin`으로 이동한다. 완료 여부는 폴더 위치만이 아니라
+현재 코드, 테스트, GitHub issue 상태, closeout 증거를 같이 본다.
+```
+
+명명 규칙 (`:18-19`): `YYMMDD_issue<NN>-<kebab-slug>` 또는 `YYMMDD_<kebab-slug>`. 과거 이동 사례를 보면 `_plan`의 접미 문자(`b`, `c`, `d`)를 **떼고** 옮긴다 (`:97, 99`):
+
+```
+- `260819b_release_speed/` → `_fin/260819_release_speed/` — v3.7.1로 완료
+- `260821_260821d-release-train/` → `_fin/260821_release_train/` — v3.10.0으로 완료
+```
+
+`_fin/` 실물도 접미 없는 형태다: `260819_release_speed`, `260821_release_train`, `260908_post_314_cleanup`.
+
+**구체 절차**:
+
+1. `git mv devlog/_plan/260819c_grok_proxy_supervision devlog/_fin/260819_grok_proxy_supervision` — 접미 `c` 제거. `_fin`에 `260819_kling_provider_feasibility`, `260819_log_detail_modal`, `260819_release_speed`가 이미 있으나 슬러그가 달라 충돌 없음.
+2. 해당 폴더에 supersede 노트 추가 (예: `900_superseded.md`). 담을 내용: 054c729f로 WP2-WP4가 실제 구현되었다는 사실, 새 제거 유닛이 그 구현물을 통째로 걷어낸다는 사실, 새 유닛 경로.
+3. `README.md` frontmatter의 `updated`를 갱신하고, 본문 상단에 supersede 배너를 넣는다.
+4. `devlog/_plan/README.md:26`의 active lane 표 행을 삭제하고, `:87` 이후의 `_fin` 이동 기록 목록에 항목을 추가한다. "구현 미착수" 오기 정정을 이동 사유에 명시한다.
+5. `scripts/check-devlog-citations.mjs`가 devlog 인용을 검사하므로, `config.ts:341`과 `:394`처럼 코드 주석이 devlog 경로를 참조하는 패턴이 이 유닛에도 있는지 확인. 현재 `260819c_grok_proxy_supervision`을 코드에서 참조하는 곳은 검색상 없다 (`010_wp2_supervisor.md:117`이 코드를 인용하는 반대 방향뿐).
+
+## 5. CI
+
+### 5-1. `.github/workflows/ci.yml` (381줄)
+
+트리거 (`:6-14`): `push` `branches: [main, dev]`, `schedule` `cron: '17 3 * * *'`, `workflow_dispatch`(40자 SHA 입력, 릴리스 후보 게이트). **`pull_request` 트리거 없음** — PR은 pr-fast.yml이 담당.
+
+잡 1 `test (${{ matrix.os }}, node ${{ matrix.node }}, npm ${{ matrix.npm }})` (`:26-27`), 매트릭스 러너. 주요 스텝 순서:
+
+```
+:57  Structure line-count drift (fast fail)  → node scripts/refresh-structure-line-counts.mjs --check
+:63  Provider registry generated-file drift  → node scripts/generate-provider-types.mjs --check
+:69  Install policy contract                 → npm run test:install-policy
+:78  Test inventory                          → npm run test:inventory
+:80  Runtime installation documentation      → npm run docs:runtime:check
+:88  Emitted doctor CLI offline and JSON contracts
+:90  Run tests                               → npm test
+:94  Lint package.json                       → npm run lint:pkg
+:102 Package install smoke                   → npm run test:package-install
+:105 Global install, update, and package-local OAuth smoke
+:108 CLI smoke (grok --help)                 → node bin/ima2.js grok --help
+:116 Graceful shutdown (SIGINT clean exit)
+:142 Publish dry-run                         → npm run publish:dry-run
+```
+
+**progrok을 직접 invoke하는 스텝은 `:108-109` 하나**:
+
+```yaml
+      - name: CLI smoke (grok --help)
+        run: node bin/ima2.js grok --help
+```
+
+`bin/commands/grok.ts`를 삭제하면 이 스텝이 실패한다. 스텝 자체를 제거하거나 다른 커맨드로 교체해야 한다.
+
+간접 invoke는 `:102`의 package install smoke — `tests/package-install-smoke.mjs:184, 238-239`가 설치된 tarball에서 `progrok --help`를 실제 실행하고 `/Usage: progrok/`를 매치한다.
+
+잡 2 `windows (node ${{ matrix.node }}, npm ${{ matrix.npm }})` (`:149-151`), `runs-on: windows-latest`, `npm ci --foreground-scripts`(`:180`). Windows 경로는 `progrok.cmd` shim에 의존한다 (`lib/grokProxyLauncher.ts:176`, `bin/commands/grok.ts:37`).
+
+### 5-2. `.github/workflows/pr-fast.yml` (209줄)
+
+트리거 (`:6-7`): `pull_request: {}` — **base 브랜치 제한 없음**. 모든 PR에서 돈다. concurrency 그룹은 PR 번호 기준, `cancel-in-progress: true` (`:9-11`).
+
+Node `22.23.0` 고정, npm `11.18.0` 핀 (`:27, 42`). ci.yml은 매트릭스 변수를 쓴다.
+
+잡 3개:
+
+- `fast` / "PR backend checks", `ubuntu-latest`, timeout 30분 (`:14-18`). 스텝: blob budget(`:44`), 루트+ui 설치, **structure line-count drift `:49-50`**, provider registry drift(`:51-52`), native deps, install policy, typecheck ×2, **test inventory `:61-62`**, build server/cli/ui, 패키지 크기 예산(`:71-72`), `npm test`(`:77-79`, timeout 5분), `lint:pkg`(`:80-81`).
+- `frontend` / "PR frontend checks", `ubuntu-latest`, timeout 25분 (`:83-86`). Playwright Chromium, `typecheck:e2e`, `build:fixture`, `test:e2e`, 증거 아티팩트 업로드 다수.
+- `gate` / "PR fast gate", `needs: [fast, frontend]`, `if: always()` (`:198-209`). 둘 다 success여야 통과.
+
+**pr-fast.yml에는 progrok 설치·실행 스텝이 없다.** package install smoke와 Windows 레인은 fast gate에서 빠져 있다 (`:73-76` 주석: "What the fast gate drops is the Windows lane and the two package smokes, which cost 573s of the 831s Windows job"). 따라서 **progrok 제거의 패키징 파손은 PR 게이트에서 보이지 않고 dev push 후 ci.yml에서야 드러난다.** wp4 검증 계획에 `workflow_dispatch`로 ci.yml을 후보 SHA에 직접 돌리는 단계가 필요하다.
+
+### 5-3. provider-canary.yml
+
+`:34-35`에 grok 시크릿 두 개:
+
+```yaml
+      CANARY_GROK_MODELS_URL: ${{ secrets.CANARY_GROK_MODELS_URL }}
+      CANARY_GROK_TOKEN: ${{ secrets.CANARY_GROK_TOKEN }}
+      CANARY_XAI_API_KEY: ${{ secrets.CANARY_XAI_API_KEY }}
+```
+
+`on: schedule (cron '23 6 * * *') / workflow_dispatch`만이며 `pull_request`에서 절대 돌지 않는다 (`:10-15`). progrok 바이너리를 설치하거나 실행하지 않고, 시크릿으로 받은 URL을 프로브할 뿐이다. `grok` lane 폐기 시 `CANARY_GROK_*` 두 항목 정리 대상.
+
+### 5-4. 기타 워크플로
+
+`wp09-startup-diagnostic.yml:65`가 `--grep 'WP02 Grok API survives|J9'`로 Grok API 저널리를 돌린다 — `grok-api`(직접 키) 경로라 progrok과 무관.
+
+`.github` 전체에서 `progrok` 문자열 매치는 0건. grok 매치는 위 3곳뿐이다.
+
+## 6. UI
+
+### 6-1. 사용자 노출 카피
+
+`ui/src` 전체에서 progrok/18645를 언급하는 코드 로직은 없고, **i18n 문자열과 라벨 하나뿐**이다.
+
+`ui/src/components/ResultMetadataModal.tsx:23`:
+
+```tsx
+  grok: "Grok OAuth / progrok",
+```
+
+프록시를 명시하는 i18n 키 (en 기준, ko/zh-Hans/zh-Hant 동일 위치):
+
+| 키 | en.json 라인 | 내용 |
+|---|---|---|
+| `grokApiBody` | 360 | "Runs through bundled progrok: mandatory search, Grok 4.5 image-and-text tool planning in English, then xAI Images API." |
+| `grokOffline` | 740 | "Grok proxy is not running." |
+| `grokOfflineHint` | 743 | "Run \`ima2 grok login\` once if needed, then start \`ima2 serve\`; ima2 starts the bundled Grok proxy automatically." |
+| `grokManagedByIma2` | 744 | "Grok runs locally inside \`ima2 serve\` through the bundled progrok proxy at 127.0.0.1:18645." |
+| `grokCompatBody` | 748 | "ima2 serve manages the bundled progrok proxy at 127.0.0.1:18645. ..." |
+| `grokEyebrow` | 1326 | "Local xAI proxy" |
+| `grokBody` | 1328 | "Uses progrok at the configured local port for xAI Images API generation." |
+| `unsupportedHelp` | 1391 | "Grok models use xAI's Images API through the bundled local proxy." |
+| (xAI 키 누락) | 1640 | "This image request will not fall back to the Grok proxy." |
+
+한국어 대응 (`ui/src/i18n/ko.json:360, 744, 748, 1328`), 중국어 간체/번체도 같은 라인 번호에 대응 문자열이 있다. **4개 로케일 × 최소 9개 키**를 wp5에서 함께 손봐야 한다.
+
+`ui/src/i18n/en.json:734, 737, 1595-1596`의 `oauthNotReady` / `oauthStarting` / "GPT OAuth proxy unavailable"은 OAuth 프록시라 무관 — 유지. `:1536`의 "proxy or transient stream transport issue"는 일반 네트워크 문구라 무관.
+
+### 6-2. 폴링 표면
+
+`routes/grok.ts` 주석이 UI 폴링 주기를 명시한다 (`routes/grok.ts:27-29`):
+
+```ts
+      // Deliberately does NOT call ensure(): the UI polls every 10s while not
+      // ready, so self-healing here would spawn a child per poll forever.
+      // Recovery is driven by the login event only.
+```
+
+`useGrokStatus` 훅이 `_plan/260819c` README의 "범위 밖"에도 등장한다 — ready 이후 폴링을 멈추지 않는 알려진 문제. `/api/grok/status`를 제거하거나 의미를 바꾸면 이 훅의 소비자 컴포넌트를 함께 확인해야 한다.
+
+## wp4/wp5 착수 전 확정해야 할 결정
+
+1. **`grok` lane을 폐기하는가, 직접 호출로 재배선하는가.** 이게 diff 규모를 2배 이상 가른다. 재배선이면 `lib/grokRuntime.ts` 축소 + 호출부 6곳 + 키 해석 경로, 폐기면 registry/models/enum/UI 라벨/문서 전반 연쇄.
+2. **advertise payload의 `grok` 키를 제거할지, `live: false` 고정으로 남길지.** 제거하면 `bin/commands/service.ts:139-151` 경고문만 손보면 되지만, `~/.ima2/server.json`은 외부 도구가 읽는 계약이다.
+3. **`findAvailablePort` export 유지 여부** — 프로덕션 소비자가 0이 되지만 테스트 2개가 쓴다.
+4. **ci.yml `:108-109` grok --help 스모크 대체** — 커맨드 삭제와 동시에 처리하지 않으면 dev push가 깨진다.
+
+검증 시 반드시 함께 돌려야 하는 생성물 게이트 3개: `node scripts/classify-tests.mjs` (인벤토리 재생성), `node scripts/refresh-structure-line-counts.mjs` (라인수), `node scripts/generate-provider-types.mjs` (registry 변경 시). package-lock 재생성 없이는 `check-install-policy.mjs:67-71`이 막는다.
+
+

--- a/devlog/_plan/260909_grok_native_oauth/004_xai_docs_aside_research.md
+++ b/devlog/_plan/260909_grok_native_oauth/004_xai_docs_aside_research.md
@@ -1,0 +1,551 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, docs-x-ai, aside, research]
+---
+
+# 004 — xAI 공식 문서·progrok 원본 조사 (Aside exec, 2026-09-09)
+
+# xAI OAuth access to `api.x.ai` for CLI tools — research notes
+
+Read-only research. No logins, no form submissions, no site-state changes.
+Compiled 2026-09-09 (Asia/Seoul).
+
+**Method:** `https://docs.x.ai/sitemap.xml` lists 183 pages; every page is available as
+Markdown by appending `.md` (stated at `https://docs.x.ai/llms.txt`). All 183 `.md` pages
+were fetched and grepped for `oauth`, `grok-cli`, `device code`, `refresh_token`,
+`expires_in`, `SuperGrok`, and `Bearer`. The progrok repo was read via raw.githubusercontent.com.
+
+---
+
+## 0. Headline finding
+
+**xAI's public developer documentation does not document OAuth as an access path to
+`https://api.x.ai`.** It documents OAuth only for signing in to the *Grok Build CLI*, whose
+inference traffic goes to a different host (`cli-chat-proxy.grok.com`). Every `api.x.ai`
+example in the docs authenticates with `Bearer $XAI_API_KEY`.
+
+The OAuth-to-`api.x.ai` behavior described in the task (client `grok-cli`, scope
+`grok-cli:access api:access`, device grant at `https://auth.x.ai/oauth2/device/code`) is
+**verifiable from xAI's live OIDC discovery document and from the progrok source**, but is
+**not described in prose anywhere on docs.x.ai**. Treat it as undocumented-but-real
+infrastructure, not a supported public contract.
+
+---
+
+## 1. What xAI's OIDC discovery document actually exposes
+
+Source: <https://auth.x.ai/.well-known/openid-configuration> (HTTP 200, fetched read-only)
+
+| Field | Value |
+| --- | --- |
+| `issuer` | `https://auth.x.ai` |
+| `authorization_endpoint` | `https://auth.x.ai/oauth2/authorize` |
+| `token_endpoint` | `https://auth.x.ai/oauth2/token` |
+| `device_authorization_endpoint` | `https://auth.x.ai/oauth2/device/code` |
+| `revocation_endpoint` | `https://auth.x.ai/oauth2/revoke` |
+| `userinfo_endpoint` | `https://auth.x.ai/oauth2/userinfo` |
+| `grant_types_supported` | `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code` |
+| `token_endpoint_auth_methods_supported` | `client_secret_basic`, `client_secret_post`, `none` (public client OK) |
+
+`scopes_supported` includes both scopes named in the task, plus many more:
+
+```
+openid, profile, email, offline_access, grok-cli:access, team:read, teams:read,
+teams:write, org:read, orgs:read, orgs:write, api:access, grok-plugins:access,
+conversations:read, conversations:write, workspaces:read, workspaces:write,
+api-keys:read, api-keys:write, logs:read, billing:read, billing:write
+```
+
+This confirms, from xAI's own server:
+- the device code grant exists at exactly `https://auth.x.ai/oauth2/device/code`;
+- `refresh_token` is a supported grant;
+- `grok-cli:access` and `api:access` are both real, advertised scopes;
+- `none` auth method means a public client with no secret is supported (which is what a CLI needs).
+
+The discovery document does **not** state token lifetimes, rotation policy, which
+`api.x.ai` routes accept the token, or which subscription tier is required. Those are not
+published.
+
+---
+
+## 2. What docs.x.ai says about OAuth (and what it does not)
+
+### 2.1 The only substantive OAuth-for-CLI page
+
+Source: <https://docs.x.ai/build/enterprise.md> (rendered: <https://docs.x.ai/build/enterprise>)
+
+Network requirements table lists `auth.x.ai` as **required**, purpose "OAuth2/OIDC
+authentication", and `cli-chat-proxy.grok.com` as **required**, purpose "Inference proxy,
+settings".
+
+Critically, `api.x.ai` is listed under **Additional** hosts, i.e. optional:
+
+> | `api.x.ai` | xAI API (direct API-key path) | Only needed when using `api_key` auth instead of the inference proxy |
+
+This is the strongest statement in the docs on the question: xAI frames `api.x.ai` as the
+**API-key path**, and routes its own OAuth-authenticated CLI to `cli-chat-proxy.grok.com`
+instead. It does not say OAuth tokens are rejected at `api.x.ai`; it says the CLI does not
+need that host when using session auth.
+
+Same page, four supported session authentication methods:
+
+> | Method | Trigger | Refreshable | Best for |
+> | Browser OIDC | `grok login` (default) | Yes | Interactive terminals with a browser |
+> | Device code | `grok login --device-auth` | Yes | SSH sessions, containers, headless hosts |
+> | External auth provider | `auth_provider_command` in config | Yes | Corporate IdPs, custom token brokers |
+> | API key | `XAI_API_KEY` env var or `model.api_key` in config | No | Scripts, CI/CD, headless automation |
+
+Device code section (same page):
+
+> For environments without a browser (SSH, containers, cloud devboxes), device code login
+> follows **RFC 8628**: `grok login --device-auth`. Grok prints a URL and a short user
+> code. Complete login on any device with a browser.
+
+Enterprise OIDC section (same page):
+
+> The flow uses PKCE and supports `refresh_token` grants for automatic renewal.
+
+Note this sentence is about *enterprise/customer IdP* configuration (`GROK_OIDC_ISSUER`,
+`GROK_OIDC_CLIENT_ID`), not about xAI's own `auth.x.ai` client.
+
+The `expires_in` mention on this page is likewise **not** about xAI's token lifetime. It
+specifies the contract for a customer-supplied external auth binary:
+
+> The command must print either a bare token string or JSON:
+> `{"access_token": "...", "refresh_token": "...", "expires_in": 3600}`
+> (`refresh_token` and `expires_in` are optional).
+
+The `3600` there is an illustrative example in a config schema for a *third-party* token
+broker. **It is not a documented xAI access-token lifetime.** Do not cite it as one.
+
+### 2.2 CLI reference
+
+Source: <https://docs.x.ai/build/cli/reference.md>
+
+> `grok login` | Sign in. `--device-auth` uses device-code authentication for headless or remote environments
+
+> `--oauth` | Use OAuth when the welcome screen starts authentication
+
+### 2.3 The single place docs.x.ai admits OAuth tokens work on `api.x.ai`
+
+Source: <https://docs.x.ai/developers/rest-api-reference/inference/other.md>
+
+> ## GET /v1/me
+> Get information about the currently authenticated caller.
+> **Works with both API keys and OAuth tokens.** Returns identity, team, and ZDR status.
+
+The response schema carries a dedicated OAuth object:
+
+> * `oauth` (object)
+>   * `client_id` (string, required) — The OAuth `client_id` of the application.
+
+This is the only endpoint on the entire docs site explicitly documented as accepting an
+OAuth token. It proves the `api.x.ai` gateway understands OAuth bearer tokens and can
+attribute them to an OAuth `client_id` — but the statement is scoped to `/v1/me` only.
+
+### 2.4 Searches that returned nothing
+
+- **`grok-cli`** — 1 hit across 183 pages, and it is a false positive: a Voximplant product
+  link `grok-client` on <https://docs.x.ai/developers/model-capabilities/audio/voice.md>.
+  The OAuth client name `grok-cli` and the scope string `grok-cli:access` appear **nowhere**
+  on docs.x.ai.
+- **`auth.x.ai`** — appears on exactly one page, `build/enterprise.md` (§2.1).
+- **device code / device_authorization** — only `build/enterprise.md` and
+  `build/cli/reference.md`, both about the `grok` CLI, neither giving the endpoint URL.
+- **`refresh_token`** — only `build/enterprise.md` (enterprise IdP + external provider
+  contract) and `grok/connectors/salesforce.md` (unrelated: Salesforce connector OAuth).
+- **`expires_in`** — only `build/enterprise.md`, in the external-provider JSON example.
+- **No page** states a refresh token lifetime, rotation policy, or reuse-detection behavior
+  for `auth.x.ai`.
+- **No page** states that OAuth tokens are restricted to SuperGrok subscribers.
+
+---
+
+## 3. Per-endpoint: are OAuth access tokens accepted as Bearer on `api.x.ai`?
+
+**Documented answer from xAI: only `/v1/me` is stated to accept OAuth tokens.** For every
+other endpoint asked about, the docs are silent on OAuth and show only API-key examples.
+
+| Endpoint | What docs.x.ai says | Source |
+| --- | --- | --- |
+| `POST /v1/images/generations` | No OAuth mention. All examples `Authorization: Bearer $XAI_API_KEY` | <https://docs.x.ai/developers/rest-api-reference/inference/images.md> |
+| `POST /v1/videos/generations`, `/edits`, `/extensions`, `GET /v1/videos/{request_id}` | No OAuth mention. All examples `Bearer $XAI_API_KEY` | <https://docs.x.ai/developers/rest-api-reference/inference/videos.md> |
+| `GET /v1/models` | No OAuth mention. Described as "List all models available to **the authenticating API key**" | <https://docs.x.ai/developers/rest-api-reference/inference/models.md> |
+| `POST /v1/responses` (+ `/compact`, `GET`/`DELETE` by id) | No OAuth mention. All examples `Bearer $XAI_API_KEY` | <https://docs.x.ai/developers/rest-api-reference/inference/responses.md> |
+| `GET /v1/me` | **"Works with both API keys and OAuth tokens."** | <https://docs.x.ai/developers/rest-api-reference/inference/other.md> |
+
+The global auth statement covering all of the above:
+
+> | Inference (responses, chat completions, embeddings, images, videos, voice, files, batches, models) | `https://api.x.ai` | `Authorization: Bearer <xAI API key>` |
+
+Source: <https://docs.x.ai/developers/rest-api-reference/inference.md>
+
+And the error table:
+
+> **401 Unauthorized** | All endpoints | No authorization header or an invalid authorization
+> token was provided. | Supply an `Authorization: Bearer <XAI_API_KEY>` header.
+
+Source: <https://docs.x.ai/developers/debugging.md>
+
+**Empirical counter-evidence (third party, not xAI):** progrok's README reports live
+requests to `/v1/videos/generations`, `/v1/videos/edits`, `/v1/videos/extensions` and image
+endpoints succeeding with an OAuth session — e.g. "T2V, I2V, R2V on `grok-imagine-video` |
+Passed, `status: done`" and "live OAuth smoke returned `Text-to-video is not supported for
+this model`" (a model-capability error, not an auth error), at
+<https://github.com/lidge-jun/progrok/blob/main/README.md>. That is observed runtime
+behavior of an undocumented path, not a documented guarantee.
+
+---
+
+## 4. Token expiry, refresh lifetime, rotation
+
+**Not documented by xAI.** No page on docs.x.ai states an `expires_in` value for
+`auth.x.ai` tokens, a refresh-token lifetime, or whether refresh tokens rotate.
+
+What can be said:
+
+- `offline_access` is an advertised scope and `refresh_token` an advertised grant type, so
+  long-lived refresh is intended by design. Source:
+  <https://auth.x.ai/.well-known/openid-configuration>
+- The only concrete `3600` in xAI's docs is the external-auth-provider JSON example
+  (<https://docs.x.ai/build/enterprise.md>), which describes a **customer's** token broker,
+  not xAI's issuer. Citing it as "xAI access tokens last 1 hour" would be wrong.
+- progrok's client code **handles rotation defensively**: it persists a new
+  `refresh_token` if the refresh response returns one, and otherwise keeps the existing
+  one — implying rotation is possible but not guaranteed. See §7.4.
+- progrok's test suite uses `expiresIn: 3600` as fixture data only
+  (<https://github.com/lidge-jun/progrok/blob/main/tests/auth.test.ts>, lines 92-97). This
+  is a test constant, not an observation of xAI's real value.
+
+**Conclusion: the typical `expires_in` is unverified.** I found no authoritative source for
+it; the plausible-looking `3600` figures both come from non-authoritative contexts.
+
+---
+
+## 5. Rate limits: OAuth session vs API key
+
+**xAI documents two entirely separate quota systems, and never reconciles them.**
+
+**API-key path — per-team tiers by cumulative spend.** Source:
+<https://docs.x.ai/developers/rate-limits.md>
+
+> Every xAI API team has per-model rate limits on two dimensions: **requests per second
+> (RPS)** and **tokens per minute (TPM)** … These limits scale with your team's **tier**,
+> which is determined by cumulative spend on the API.
+
+Tiers: Tier 0 ($0) → Tier 1 ($50) → Tier 2 ($250) → Tier 3 ($1,000) → Tier 4 ($5,000) →
+Enterprise. Example per-model caps: `grok-4.6` T0 150 RPS / 50M TPM up to T4 500 RPS / 100M
+TPM; `grok-imagine-image` T0 6 RPS → T4 100 RPS; `grok-imagine-video` T0 10 RPS → T4 158 RPS.
+Exceeding returns `429 Too Many Requests`.
+
+> Rate limit tiers apply to text and embedding models. For increases to Voice and Imagine
+> API limits, contact sales@x.ai.
+
+**Subscription path — one shared weekly usage pool.** Source:
+<https://docs.x.ai/grok/faq.md>
+
+> Instead of separate daily limits for each product (like Chat, Imagine, Voice, or Build),
+> you get one shared weekly usage pool that you can spend however you like across any Grok
+> product.
+
+> A percentage breakdown by product (**API**, Build, Chat, Imagine, Voice).
+
+That parenthetical is the most relevant line in the whole docs set for this question: the
+subscription usage meter has an **"API"** category alongside Build/Chat/Imagine/Voice,
+which is consistent with account-session-authenticated API usage being metered against the
+weekly subscription pool rather than against the spend-based API tier ladder. xAI does not
+say this explicitly, so treat it as a strong hint, not a documented rule.
+
+> Different products cost different amounts depending on how much compute that product
+> requires… The usage pool limit resets every week on a schedule shown in the Usage tab in
+> Settings.
+
+**No page compares OAuth-session limits to API-key limits directly.**
+
+Third-party corroboration that OAuth is subject to account-side limits rather than API
+tiers, from progrok's README:
+
+> These commands call xAI directly with OAuth and may be subject to product access, rate
+> limits, quota, and account capability.
+
+and a live rejection tied to account entitlement, not tier:
+
+> `1080p` | Failed for this team: `1080p video resolution is not available for your team`
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/README.md>
+
+---
+
+## 6. Statements that OAuth tokens require a SuperGrok subscription
+
+**xAI: no such statement exists.** The string "SuperGrok" appears on 9 docs pages, all in
+consumer product context (billing, cancellation, refunds, weekly usage limits, Grok Bot,
+mobile) — never in connection with OAuth, `auth.x.ai`, or `api.x.ai`. Sources:
+<https://docs.x.ai/grok/faq.md>, <https://docs.x.ai/grok/overview.md>,
+<https://docs.x.ai/grok/user-guide.md>, <https://docs.x.ai/grok/management.md>,
+<https://docs.x.ai/grok-bot/get-started.md>, <https://docs.x.ai/grok-bot/faq.md>,
+<https://docs.x.ai/grok-bot/mobile.md>, <https://docs.x.ai/grok-bot/teams-and-enterprises.md>,
+<https://docs.x.ai/integrations/hubspot-mcp-setup.md>.
+
+**The SuperGrok requirement is asserted only by progrok, not by xAI:**
+
+> Requires an active SuperGrok subscription. progrok does not bypass xAI account access,
+> quotas, pricing, or product limits.
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/README.md>
+
+> Log in to xAI via OAuth (SuperGrok subscription required).
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/commands/login.ts> (the `login`
+command's `.description(...)` string)
+
+> Log in with your xAI account (SuperGrok subscription required).
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/docs/api.md>
+
+---
+
+## 7. progrok implementation details
+
+Repo: <https://github.com/lidge-jun/progrok> — "Use Grok models for free via OAuth proxy.
+No API key needed.", public, default branch `main`, MIT.
+
+### 7.1 Client ID constant
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/constants.ts>
+
+```ts
+// xAI shared OAuth Client (same as hermes-agent & openclaw — MIT licensed)
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE =
+  "openid profile email offline_access grok-cli:access api:access";
+export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+```
+
+**Client ID: `b1a00492-073a-47ea-816f-4c329264a828`** — a UUID, not the literal string
+`grok-cli`. The `grok-cli` identity enters through the **scope** `grok-cli:access`, which
+progrok requests together with `api:access`. The comment attributes the client to
+hermes-agent and openclaw; the README elaborates:
+
+> progrok's OAuth client attribution comes from Hermes Agent and OpenClaw under their MIT
+> licenses.
+
+Other constants from the same file:
+
+| Constant | Value |
+| --- | --- |
+| `XAI_OAUTH_CALLBACK_HOST` / `PORT` / `PATH` | `127.0.0.1` / `56121` / `/callback` |
+| `XAI_OAUTH_REDIRECT_URI` | `http://127.0.0.1:56121/callback` (comment: "MUST match registered redirect URI") |
+| `XAI_OAUTH_CORS_ORIGINS` | `["auth.x.ai", "accounts.x.ai"]` |
+| `XAI_OAUTH_TIMEOUT_MS` | `5 * 60 * 1000` (5 min) |
+| `XAI_OAUTH_FETCH_TIMEOUT_MS` | `30 * 1000` |
+| `XAI_DEVICE_CODE_POLL_INTERVAL_MS` | `5 * 1000` |
+| `XAI_API_BASE_URL` | `https://api.x.ai/v1` |
+| `CONFIG_DIR` / `AUTH_FILE` | `~/.progrok` / `~/.progrok/auth.json` |
+| `PROXY_DEFAULT_HOST` / `PORT` | `127.0.0.1` / `18645` |
+
+### 7.2 Refresh skew
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/constants.ts>
+
+```ts
+// Token refresh
+export const TOKEN_REFRESH_SKEW_MS = 2 * 60 * 1000;
+```
+
+**Refresh skew = 2 minutes (120,000 ms).** Applied in `getValidBearer()`:
+
+```ts
+if (
+  tokens.expiresAt &&
+  Date.now() + TOKEN_REFRESH_SKEW_MS >= tokens.expiresAt
+) { /* refresh */ }
+```
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/token-store.ts>
+
+Documented as: "The token is auto-refreshed ~2 minutes before expiry."
+Source: <https://github.com/lidge-jun/progrok/blob/main/docs/api.md>
+
+### 7.3 Exact `auth.json` fields
+
+On-disk shape written by `saveTokens()`, file mode `0o600`, at `~/.progrok/auth.json`.
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/token-store.ts>
+
+```ts
+export interface TokenData {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  tokenEndpoint?: string;
+  email?: string;
+  idToken?: string;
+}
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `accessToken` | string (required) | The OAuth bearer token |
+| `refreshToken` | string, optional | From `refresh_token` |
+| `expiresAt` | number, optional | Absolute epoch ms, computed as `Date.now() + expiresIn * 1000` — **not** the raw `expires_in` |
+| `tokenEndpoint` | string, optional | Persisted from OIDC discovery, e.g. `https://auth.x.ai/oauth2/token` |
+| `email` | string, optional | Decoded from the `id_token` JWT payload's `email` claim (base64url, second segment); malformed JWTs silently ignored |
+| `idToken` | string, optional | Raw OIDC ID token |
+
+Matching documented example (note: docs sample omits `idToken`):
+
+```json
+{
+  "accessToken": "eyJ...",
+  "refreshToken": "...",
+  "expiresAt": 1780152218787,
+  "tokenEndpoint": "https://auth.x.ai/oauth2/token",
+  "email": "user@example.com"
+}
+```
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/docs/api.md>
+
+The wire-format interface is kept separate from the on-disk one:
+
+```ts
+export interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  token_type?: string;
+}
+```
+
+### 7.4 Refresh request and rotation handling
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/token-store.ts>
+
+```ts
+body: new URLSearchParams({
+  grant_type: "refresh_token",
+  client_id: XAI_OAUTH_CLIENT_ID,
+  refresh_token: tokens.refreshToken,
+}),
+```
+
+Public-client refresh: `client_id` in the body, **no client secret**, posted as
+`application/x-www-form-urlencoded` to the stored `tokenEndpoint` with a 30s timeout.
+
+Rotation handling — keep the new refresh token if one comes back, otherwise reuse the old:
+
+```ts
+refreshToken:
+  (typeof refreshed.refresh_token === "string"
+    ? refreshed.refresh_token
+    : undefined) || tokens.refreshToken,
+```
+
+Failure modes: non-OK response → `"Token refresh failed. Run \`progrok login\` again."`;
+missing/non-string `access_token` → `"Token refresh returned invalid access_token…"`;
+expired with no refresh token or no token endpoint → `"Token expired and no refresh token
+available…"`. Note `saveTokens` on the refresh path does **not** pass `idToken`, so a
+previously stored `idToken`/`email` is dropped after the first refresh.
+
+### 7.5 Device code flow
+
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/auth/device-code.ts>
+
+- Endpoint is **not hardcoded**: it comes from `fetchOIDCDiscovery()` →
+  `device_authorization_endpoint`, which xAI's live discovery doc resolves to
+  `https://auth.x.ai/oauth2/device/code`. If absent, it throws "xAI does not support device
+  code flow via OIDC discovery".
+- Device code request POSTs `client_id` + `scope` (form-encoded).
+- Poll interval: `Math.max((dc.interval || 5) * 1000, XAI_DEVICE_CODE_POLL_INTERVAL_MS)` —
+  server hint, floored at 5s.
+- Deadline: `Date.now() + dc.expires_in * 1000`.
+- Poll body: `grant_type: "urn:ietf:params:oauth:grant-type:device_code"` + `client_id` +
+  `device_code`.
+- RFC 8628 error handling: `authorization_pending` → continue; `slow_down` → extra 5s sleep
+  then continue; anything else → throw. Timeout → "Device code expired. Please try again."
+
+Endpoint trust is pinned in <https://github.com/lidge-jun/progrok/blob/main/src/auth/discovery.ts>:
+every discovered endpoint must be HTTPS and its hostname must be `x.ai` or end in `.x.ai`,
+else "OIDC discovery returned untrusted …".
+
+### 7.6 How 401 is handled in the proxy
+
+`src/commands/proxy.ts` is a thin commander wrapper — it only checks `loadTokens()?.accessToken`
+exists before starting the server, then delegates to `startProxy()`.
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/commands/proxy.ts>
+
+The actual handling is in `handleProxy()`.
+Source: <https://github.com/lidge-jun/progrok/blob/main/src/proxy/server.ts>
+
+**There is exactly one 401 in the proxy, and it is generated locally — never propagated
+from upstream and never retried.**
+
+```ts
+let bearer: string;
+try {
+  bearer = await getValidBearer();
+} catch (err) {
+  res.status(401).json({
+    error: { message: (err as Error).message, type: "auth_error" },
+  });
+  return;
+}
+```
+
+Behavior, precisely:
+
+1. **Local 401 only.** The proxy returns 401 solely when `getValidBearer()` throws — i.e.
+   not logged in, token expired with no refresh token, or refresh failed. Body shape:
+   `{ error: { message, type: "auth_error" } }`.
+2. **Refresh is proactive, not reactive.** Renewal is driven entirely by the 2-minute skew
+   check *before* the request goes out. There is no "upstream said 401 → refresh → replay"
+   path anywhere in the file.
+3. **Upstream 401s pass straight through.** `res.status(upstream.status)` forwards whatever
+   `api.x.ai` returned verbatim. A 401 from xAI (e.g. a token revoked mid-session, or a
+   route that rejects OAuth) reaches the client unmodified and untranslated.
+4. **Client credentials are discarded.** `authorization` is in the `HOP_BY_HOP` deny set, so
+   the caller's header is stripped, then `fwdHeaders["Authorization"] = \`Bearer ${bearer}\``
+   is set. Confirmed by docs: "the proxy strips any `Authorization` header you send and
+   replaces it with the stored OAuth bearer token."
+5. Other statuses the proxy originates itself: **413** when the body exceeds
+   `MAX_BODY_BYTES` (100 MB), and **502** `type: "upstream_error"` when `fetch` throws and
+   headers were not yet sent.
+
+Routing: `app.all("/v1/*")` → upstream `${XAI_API_BASE_URL}${relPath}${qs}`, i.e. every
+`/v1/*` path including `/v1/images/generations`, `/v1/videos/*`, `/v1/models`, and
+`/v1/responses`. Response body is streamed chunk-by-chunk (SSE-capable);
+`content-encoding` and `content-length` are dropped from forwarded response headers. A
+`/health` route returns `{"status":"ok","upstream":"xAI Grok","proxy":"progrok"}`. Binding
+to `0.0.0.0`/`::` logs "⚠ Bound to all interfaces — your OAuth token is accessible on the
+local network!".
+
+---
+
+## 8. Bottom line
+
+| Question | Answer | Basis |
+| --- | --- | --- |
+| Does docs.x.ai document OAuth access to `api.x.ai`? | **No** — only `/v1/me` is stated to accept OAuth tokens | <https://docs.x.ai/developers/rest-api-reference/inference/other.md> |
+| Does docs.x.ai mention `grok-cli` or `grok-cli:access`? | **No** (0 real hits in 183 pages) | full-site `.md` grep |
+| Is the device endpoint real? | **Yes**, `https://auth.x.ai/oauth2/device/code` | <https://auth.x.ai/.well-known/openid-configuration> |
+| Are `grok-cli:access` + `api:access` real scopes? | **Yes**, both in `scopes_supported` | same discovery doc |
+| Is `refresh_token` supported? | **Yes**, in `grant_types_supported` | same discovery doc |
+| Typical `expires_in`? | **Unverified.** Both `3600` sightings are non-authoritative | §4 |
+| Refresh rotation policy? | **Undocumented.** progrok codes defensively for either case | §7.4 |
+| OAuth Bearer on `/v1/images/generations`, `/v1/videos`, `/v1/models`, `/v1/responses`? | **Not documented by xAI**; all examples use `$XAI_API_KEY`. progrok reports live OAuth success on image/video endpoints | §3 |
+| OAuth rate limits vs API key? | **Never compared.** API keys → spend-based tiers w/ RPS+TPM; subscriptions → one weekly pool with an "API" category | §5 |
+| "OAuth is for SuperGrok subscribers" — does xAI say this? | **No.** Only progrok asserts it | §6 |
+| Client ID constant | `b1a00492-073a-47ea-816f-4c329264a828` | `src/auth/constants.ts` |
+| Refresh skew | **2 minutes** (`TOKEN_REFRESH_SKEW_MS = 2 * 60 * 1000`) | `src/auth/constants.ts` |
+| `auth.json` fields | `accessToken`, `refreshToken?`, `expiresAt?`, `tokenEndpoint?`, `email?`, `idToken?` | `src/auth/token-store.ts` |
+| Proxy 401 handling | Local-only 401 on `getValidBearer()` failure; **no retry-on-upstream-401**; upstream 401 passed through | `src/proxy/server.ts` |
+
+**Risk note for ima2:** the OAuth→`api.x.ai` path is undocumented by the vendor. xAI's own
+CLI deliberately sends OAuth-authenticated inference to `cli-chat-proxy.grok.com` and
+describes `api.x.ai` as "the direct API-key path". An undocumented path carries no
+compatibility promise and can be changed or closed without a release note. Also note that
+because progrok never retries on an upstream 401, a token revoked mid-session surfaces as a
+raw 401 to the calling client rather than triggering re-auth.

--- a/devlog/_plan/260909_grok_native_oauth/010_wp2_xai_auth.md
+++ b/devlog/_plan/260909_grok_native_oauth/010_wp2_xai_auth.md
@@ -15,7 +15,7 @@ tags: [ima2-gen, devlog, grok, xai, oauth, wp2, xaiAuth]
 | 경로 | 종류 | 내용 |
 |---|---|---|
 | `lib/xaiAuth.ts` | NEW (~260줄) | 001 §6의 공개 API 그대로. leaf 모듈: `node:fs`, `node:crypto`, `node:os`, `node:path`만 import |
-| `lib/errors/providerMap.ts` | MODIFY | `GROK_AUTH_REQUIRED`(401), `GROK_AUTH_REFRESH_FAILED`(502) 항목 추가. 기존 `GROK_AUTH_FAILED` 유지 |
+| `lib/errors/providerMap.ts` | MODIFY | `PROVIDER_ERROR_MAP`(`satisfies Record<string, GenerationErrorClass>`)에 `GROK_AUTH_REQUIRED: "AUTH_EXPIRED"`, `GROK_AUTH_REFRESH_FAILED: "NETWORK_FAILURE"` 추가. HTTP status는 별도 함수 `statusForErrorCode`(:4-15)에 401/502 두 줄 추가. 기존 `GROK_AUTH_FAILED` 유지. (감사 B3: 값은 status가 아니라 error class; 미등록 코드는 `envelope.ts:14`에서 rawCode/errorClass가 빈 객체로 떨어진다) |
 | `routes/auth.ts` | MODIFY | `GROK_CLIENT_ID`/`GROK_SCOPE`/`GROK_TOKEN_URL` 로컬 상수 3개(:11-13)를 `lib/xaiAuth.ts` export로 교체. `saveGrokTokens`(:48-74) 본문을 `saveGrokCredentials` 호출로 교체(기존 `idToken` 보존 로직 포함) |
 | `tests/xai-auth-contract.test.ts` | NEW | 아래 검증 표 |
 | `docs/migration/runtime-test-inventory.md` | 생성물 | `node scripts/classify-tests.mjs` 재생성 |
@@ -98,7 +98,9 @@ export async function getGrokAccessToken(opts = {}): Promise<string> {
 
 `GrokAuthError`는 `lib/errors/classes.ts`의 기존 클래스 계층을 따르되, leaf 제약 때문에
 `lib/xaiAuth.ts` 안에서 `Error`를 직접 확장하고 `code`/`status`를 갖는다
-(`lib/grokImageCore.ts:78` `grokError`와 같은 shape이라 기존 라우트 에러 봉투가 그대로 처리).
+(`lib/grokImageCore.ts:80` `grokError`와 같은 shape이라 기존 라우트 에러 봉투가 그대로 처리).
+
+`loadGrokCredentials`는 **반드시 동기**(`readFileSync`)여야 한다. `lib/runtimeContext.ts:68` 주석대로 어댑터 `validateAuth()`/`listModels()`와 wp4의 `grokLaneState()`가 동기 호출자다(감사 N9).
 
 ## `routes/auth.ts` diff
 
@@ -134,8 +136,9 @@ export async function getGrokAccessToken(opts = {}): Promise<string> {
 | discovery가 `https://evil.x.ai/token` 반환 | throw (D6) | 스텁 discovery |
 | tmp 파일 잔존 없음 | 디렉터리에 `auth.json`만 | 갱신 후 readdir |
 
-명령: `node --experimental-strip-types --test tests/xai-auth-contract.test.ts`
-(PLAN-VERIFIER-REAL-01: 이 명령은 새 파일을 직접 인자로 읽는다).
+명령: `node --experimental-test-module-mocks --import tsx --test tests/xai-auth-contract.test.ts`
+(PLAN-VERIFIER-REAL-01: 정식 러너 `scripts/run-tests.mjs:19`와 같은 플래그. 이 저장소는 `.js` 확장자로 TS를 import하므로 `--experimental-strip-types`는 `ERR_MODULE_NOT_FOUND`로 실패한다 — 감사 B4에서 실측. 새 파일을 직접 인자로 읽는다.)
+새 테스트 파일에 분류 태그 주석은 불필요하다(`scripts/classify-tests.mjs:21-34`는 import 패턴만 본다); `npm run test:inventory` 재생성만 필요.
 전체: `npm run typecheck && npm run typecheck:tests && npm test && npm run test:inventory`.
 
 ## 우회 경로 (PLAN-BYPASS-NAMED-01)

--- a/devlog/_plan/260909_grok_native_oauth/010_wp2_xai_auth.md
+++ b/devlog/_plan/260909_grok_native_oauth/010_wp2_xai_auth.md
@@ -1,0 +1,144 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, wp2, xaiAuth]
+---
+
+# 010 — wp2: `lib/xaiAuth.ts` 코어
+
+브랜치 `codex/grok-native-oauth-02-xai-auth`, base `codex/grok-native-oauth-01-roadmap`.
+이 레이어는 새 모듈과 그 계약 테스트만 추가한다. 프로덕션 호출자는 wp3에서 붙는다.
+클래스 C3 (자격증명 보안 경계 → C4 수준 검증: negative case 필수).
+
+## 파일 변경 지도
+
+| 경로 | 종류 | 내용 |
+|---|---|---|
+| `lib/xaiAuth.ts` | NEW (~260줄) | 001 §6의 공개 API 그대로. leaf 모듈: `node:fs`, `node:crypto`, `node:os`, `node:path`만 import |
+| `lib/errors/providerMap.ts` | MODIFY | `GROK_AUTH_REQUIRED`(401), `GROK_AUTH_REFRESH_FAILED`(502) 항목 추가. 기존 `GROK_AUTH_FAILED` 유지 |
+| `routes/auth.ts` | MODIFY | `GROK_CLIENT_ID`/`GROK_SCOPE`/`GROK_TOKEN_URL` 로컬 상수 3개(:11-13)를 `lib/xaiAuth.ts` export로 교체. `saveGrokTokens`(:48-74) 본문을 `saveGrokCredentials` 호출로 교체(기존 `idToken` 보존 로직 포함) |
+| `tests/xai-auth-contract.test.ts` | NEW | 아래 검증 표 |
+| `docs/migration/runtime-test-inventory.md` | 생성물 | `node scripts/classify-tests.mjs` 재생성 |
+| `structure/01-file-function-map.md` | 생성물 | `node scripts/refresh-structure-line-counts.mjs` + `lib/xaiAuth.ts` 행 수동 추가 |
+
+## `lib/xaiAuth.ts` 상세
+
+001 §6 시그니처를 따른다. 구현 규칙:
+
+```ts
+// 상수 — routes/auth.ts:11-13 과 vendor progrok dist/index.js:16-18, 28 과 동일 값
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+export const XAI_OAUTH_DISCOVERY_URL = "https://auth.x.ai/.well-known/openid-configuration";
+export const XAI_TOKEN_ENDPOINT_FALLBACK = "https://auth.x.ai/oauth2/token";
+export const XAI_TOKEN_REFRESH_SKEW_MS = 120_000;
+export const XAI_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+const XAI_TRUSTED_AUTH_HOSTS = new Set(["auth.x.ai", "accounts.x.ai"]);   // 001 D6
+const FLIGHT_STALE_MS = 120_000;
+const TERMINAL_FAILURE_TTL_MS = 30_000;
+const TERMINAL_OAUTH_ERRORS = new Set(["invalid_grant", "refresh_token_reused", "revoked_token"]);
+```
+
+파일 I/O:
+
+```ts
+export function grokAuthFilePath(homeDir = homedir()) { return join(homeDir, ".progrok", "auth.json"); }
+
+export function loadGrokCredentials(homeDir?: string): GrokCredentials | null {
+  // readFileSync + JSON.parse; 실패 시 null. accessToken이 문자열이 아니면 null.
+  // 알 수 없는 키는 보존하기 위해 파싱 결과를 GrokCredentials & Record<string, unknown> 로 유지.
+}
+
+export function saveGrokCredentials(creds: GrokCredentials, homeDir?: string): void {
+  // routes/auth.ts:48-74 패턴을 그대로 옮긴다:
+  // mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // tmp = join(dir, `auth.json.tmp-${randomBytes(6).toString("hex")}`)
+  // writeFileSync(tmp, JSON.stringify(creds, null, 2), { mode: 0o600 }); renameSync(tmp, target)
+}
+```
+
+토큰 요청 (`postXaiToken`) — OpenCodex xai.ts:100-115를 풀어 쓰되 D1~D4를 수정:
+
+```ts
+function retryDelayMs(attempt: number, retryAfter: string | null, random: () => number): number {
+  const fromHeader = parseRetryAfterMs(retryAfter);       // D2: 정수초 + HTTP-date + 소수초
+  if (fromHeader !== undefined) return Math.min(fromHeader, 60_000);   // D1: 서버 지시 우선, 절대 상한 60s
+  const base = attempt === 1 ? 100 : 250;
+  return Math.round(base * (0.75 + random() * 0.5));
+}
+// 루프: attempt 1..3. signal?.aborted 면 즉시 throw (D3). TimeoutError 는 재시도 안 함.
+// 429 또는 >=500 만 재시도. 소진 시 XaiTokenRequestError(..., { cause: last }) (D4).
+// 실패 응답 body 는 text() 로 소비하거나 body?.cancel() (D9).
+```
+
+refresh와 single-flight:
+
+```ts
+export async function refreshXaiToken(refreshToken, opts): Promise<GrokCredentials> {
+  const tokenEndpoint = validateXaiAuthEndpoint(opts?.tokenEndpoint ?? (await discoverXaiOAuthEndpoints(opts?.signal)).tokenEndpoint);
+  const payload = await postXaiToken(tokenEndpoint, { grant_type: "refresh_token", client_id: XAI_OAUTH_CLIENT_ID, refresh_token: refreshToken }, opts?.signal, opts?.deps);
+  // expiresAt = typeof expires_in === "number" ? now + expires_in*1000 : undefined  (R3, D5: 3600 폴백 없음)
+  // refreshToken = payload.refresh_token || refreshToken  (rotation 폴백)
+}
+
+export async function getGrokAccessToken(opts = {}): Promise<string> {
+  if (Date.now() < terminalFailureUntil) throw new GrokAuthError("GROK_AUTH_REQUIRED", ...);
+  const stored = loadGrokCredentials(opts.homeDir);
+  if (!stored) throw new GrokAuthError("GROK_AUTH_REQUIRED", "Grok login required. Run ima2 grok login.");
+  if (opts.rejectedAccessToken && stored.accessToken !== opts.rejectedAccessToken) return stored.accessToken; // 세대 확인
+  const expiring = stored.expiresAt !== undefined && Date.now() + XAI_TOKEN_REFRESH_SKEW_MS >= stored.expiresAt;
+  if (!opts.forceRefresh && !expiring) return stored.accessToken;
+  if (!stored.refreshToken) throw new GrokAuthError("GROK_AUTH_REQUIRED", "Grok session expired and cannot be refreshed.");
+  return (await runRefreshFlight(stored, opts)).accessToken;
+}
+// runRefreshFlight: 진행 중 비행이 FLIGHT_STALE_MS 이내면 join. finally 에서 자기 자신일 때만 해제.
+// terminal oauthError → terminalFailureUntil = now + TTL, GROK_AUTH_REQUIRED. 그 외 → GROK_AUTH_REFRESH_FAILED.
+// 성공 시 saveGrokCredentials({ ...stored, ...fresh })  — stored 의 idToken/email/accountId 보존.
+```
+
+`GrokAuthError`는 `lib/errors/classes.ts`의 기존 클래스 계층을 따르되, leaf 제약 때문에
+`lib/xaiAuth.ts` 안에서 `Error`를 직접 확장하고 `code`/`status`를 갖는다
+(`lib/grokImageCore.ts:78` `grokError`와 같은 shape이라 기존 라우트 에러 봉투가 그대로 처리).
+
+## `routes/auth.ts` diff
+
+```diff
+-const GROK_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+-const GROK_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+-const GROK_TOKEN_URL = "https://auth.x.ai/oauth2/token";
++import { XAI_OAUTH_CLIENT_ID as GROK_CLIENT_ID, XAI_OAUTH_SCOPE as GROK_SCOPE,
++  XAI_TOKEN_ENDPOINT_FALLBACK as GROK_TOKEN_URL, saveGrokCredentials, loadGrokCredentials } from "../lib/xaiAuth.js";
+```
+
+`saveGrokTokens`(:48-74)는 email 추출만 남기고 쓰기를 `saveGrokCredentials({ ...(loadGrokCredentials() ?? {}), accessToken, refreshToken, expiresAt, tokenEndpoint, idToken: tokens.id_token, email })`로 교체. 동작 동일, 파일 형식 동일(2칸 들여쓰기, 0600).
+
+## 검증 (C 게이트)
+
+`tests/xai-auth-contract.test.ts` — 격리 HOME(`mkdtemp`)과 `globalThis.fetch` 스텁으로 네트워크 없이 실행.
+
+| 시나리오 | 기대 | 활성화 방법 |
+|---|---|---|
+| 파일 없음 | `GROK_AUTH_REQUIRED`, fetch 호출 0 | 빈 HOME |
+| 유효 토큰 (expiresAt 미래) | 저장된 accessToken 반환, fetch 0 | expiresAt = now + 1h |
+| 만료 임박 (now+60s) | refresh 1회, 새 토큰 반환, 파일 갱신, 0600 유지 | expiresAt = now + 60s, fetch 스텁이 새 access_token 반환 |
+| expiresAt 없음 | refresh 없이 반환 | 필드 삭제 |
+| 동시 12건 만료 임박 | fetch 호출 정확히 1 | `Promise.all(12 × getGrokAccessToken())` |
+| refresh_token rotation 없음 | 기존 refreshToken 보존 | 응답에 refresh_token 없음 |
+| idToken 보존 | 갱신 후 파일에 idToken 남음 | 초기 파일에 idToken 포함 |
+| invalid_grant | `GROK_AUTH_REQUIRED`, 파일 삭제 안 됨, 30s 내 재호출은 fetch 0 | 스텁 400 `{error:"invalid_grant"}` |
+| 503 ×3 | `GROK_AUTH_REFRESH_FAILED`, 3회 시도 | 스텁 503, deps.sleep 즉시 |
+| 429 + Retry-After: 5 | 두 번째 시도 전 sleep(5000) | deps.sleep 캡처 |
+| 429 + Retry-After HTTP-date | Date.parse 결과 사용 | D2 |
+| 커스텀 abort reason | 재시도 없이 그 reason throw | `controller.abort(new Error("x"))` |
+| rejectedAccessToken ≠ 저장값 | refresh 없이 저장값 반환 | 세대 확인 |
+| discovery가 `https://evil.x.ai/token` 반환 | throw (D6) | 스텁 discovery |
+| tmp 파일 잔존 없음 | 디렉터리에 `auth.json`만 | 갱신 후 readdir |
+
+명령: `node --experimental-strip-types --test tests/xai-auth-contract.test.ts`
+(PLAN-VERIFIER-REAL-01: 이 명령은 새 파일을 직접 인자로 읽는다).
+전체: `npm run typecheck && npm run typecheck:tests && npm test && npm run test:inventory`.
+
+## 우회 경로 (PLAN-BYPASS-NAMED-01)
+
+이 레이어에 새 enforcement는 없다. 0600은 파일시스템 계층의 조기 경고이며, 다른 프로세스(progrok 잔존 시)가
+같은 파일을 0644로 다시 쓰면 무효화된다. 최종 계층: 없음.

--- a/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
+++ b/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
@@ -44,8 +44,14 @@ export function getGrokEndpoint(path: string, credential: GrokCredential) {
 /**
  * 401 을 정확히 1회 refresh 후 재시도. grokFetchWithRetry 는 헤더를 다시 만들 수 없으므로 여기서만 처리(R6).
  * doFetch 는 credential 을 받아 요청을 만든다. 이미지/비디오 시작처럼 재시도 금지 호출도 401 은 생성 전 거부라 안전.
+ *
+ * 중첩 순서 고정(감사 B2): 바깥 = fetchWithGrokAuth, 안쪽 = grokFetchWithRetry.
+ *   fetchWithGrokAuth(ctx, p, (c) => grokFetchWithRetry(() => fetch(getGrokEndpoint(path, c).url, ...)))
+ * 이유: 반대로 두면 5xx 재시도마다 resolveGrokCredential 이 돌아 순차 refresh 가 반복될 수 있고,
+ * retryBackoffDelayMs 가 res.headers 를 읽으므로 안쪽 응답형은 RetryResponse 여야 한다.
+ * 401→refresh 후 5xx 예산이 리셋되는 것(최악 3×3)은 감수한다.
  */
-export async function fetchWithGrokAuth<R extends { status: number }>(
+export async function fetchWithGrokAuth<R extends { status: number; headers: Headers }>(
   ctx: RouteRuntimeContext, provider: "grok" | "grok-api",
   doFetch: (credential: GrokCredential) => Promise<R>, opts?: { signal?: AbortSignal },
 ): Promise<R> {
@@ -71,12 +77,14 @@ export async function fetchWithGrokAuth<R extends { status: number }>(
 | `lib/grokImagePlanner.ts:207,283` | MODIFY | `directApiKey?: string` → `credential: GrokCredential`; :212, :310 호출 갱신 |
 | `lib/providers/adapters/grokOperations.ts:28,52,58-61,79,86,91-94` | MODIFY | 옵션 필드 교체; `trustedProxyOrigin` 3곳 제거(직결 URL은 공개 https) |
 | `lib/providers/adapters/grokMultimodeOperations.ts:48,98,101-104` | MODIFY | 동일 |
-| `lib/providers/adapters/grokExecution.ts:27,59,84,96` | MODIFY | `const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined` → `const credential = await resolveGrokCredential(ctx, activeProvider, { signal })`. 4곳 |
+| `lib/providers/adapters/grokExecution.ts:27,84,96` | MODIFY | `const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined` → `const credential = await resolveGrokCredential(ctx, activeProvider, { signal })`. 이 3곳은 이미 async |
+| `lib/providers/adapters/grokExecution.ts:55-63,115` | MODIFY | `prepareGrokNode`는 **동기 함수**(감사 B1). `async`로 승격해 `Promise<PreparedImageExecution<"node">>`를 반환하고 :115 `case "node": return prepareGrokNode(...)`를 `return await prepareGrokNode(...)`로. prepare 시점 캡처(:58 주석 "retries retain this key") 계약은 유지 |
 | `lib/grokVideoAdapter.ts:247,282,398` | MODIFY | `options.directApiKey` → `options.credential` |
 | `lib/grokVideoPoll.ts:42,45,91` | MODIFY | 동일 |
 | `routes/video.ts:543,558` | MODIFY | `provider === "grok-api" ? ctx.xaiApiKey : undefined` → `await resolveGrokCredential(ctx, provider)` |
 | `lib/videoExtendI2vOperation.ts:68` | MODIFY | 동일 |
-| `routes/videoExtended.ts:69-70,206,341,435` | MODIFY | `videoProxyUrl` 삭제. 세 라우트가 `fetchWithGrokAuth(ctx, provider, (c) => fetch(getGrokEndpoint(path, c).url, ...))` 사용. **provider는 요청 body에서 읽되 기본 "grok"** (지금은 grok-api 사용자도 프록시로 새던 잠재 버그를 함께 고침) |
+| `routes/videoExtended.ts:69-70,206,341,435` | MODIFY | `videoProxyUrl` 삭제. 세 핸들러에 `const provider = req.body?.provider === "grok-api" ? "grok-api" : "grok"` 파싱을 **새로 추가**(현재 provider 파싱 없음, 감사 B6) 후 `fetchWithGrokAuth(ctx, provider, (c) => fetch(getGrokEndpoint(path, c).url, ...))`. :214, :347의 `pollVideoUntilDone(ctx, request_id, { signal })`도 `{ signal, credential }`로 |
+| `tests/backend-hardening-contract.test.js:24` | MODIFY | 소스 텍스트 정규식 `/pollVideoUntilDone\(ctx, request_id, \{ signal \}\)/`를 `{ signal, credential }` 형태로 갱신 (감사 B6) |
 | `lib/agentPlannerModel.ts:115` | MODIFY | `getGrokEndpoint(ctx, "/v1/chat/completions")` → `fetchWithGrokAuth(ctx, "grok", ...)` |
 | `lib/promptBuilder/router.ts:107-112` | MODIFY | `resolveGrokCredential(ctx, backend)`로 통일; grok도 자격증명 없으면 `unavailableBackendError("grok")` |
 | `routes/grok.ts` | REWRITE | probe token 제거. `fetchWithGrokAuth(ctx, "grok", (c) => fetch(getGrokEndpoint("/v1/models", c).url, {headers, signal}))`. `GrokAuthError.code === "GROK_AUTH_REQUIRED"` → `{status:"offline", reason:"login_required"}`, `GROK_AUTH_REFRESH_FAILED` → `{status:"error", reason}`. 응답 리터럴 4종 유지(R8) |
@@ -89,7 +97,8 @@ export async function fetchWithGrokAuth<R extends { status: number }>(
 | 파일 | 변경 |
 |---|---|
 | `tests/_executionRouteHarness.ts:164` | `grokUrl` 픽스처 대신 격리 HOME + `auth.json` 작성 헬퍼 `seedGrokAuth(home, {accessToken, expiresAt})` 추가; `ctx.grokAuthHomeDir` 주입 |
-| `tests/_videoExecutionFixture.ts:97` 외 `Bearer dummy` 단정 5곳 | `Bearer <seeded token>` 으로 교체 |
+| `Bearer dummy` 단정 **12곳** (`rg 'Bearer dummy' tests/`: `_videoExecutionFixture.ts:97`, `videoRoute.test.ts:44`, `videoExtendedRoute.test.ts:44`, `video-download-cancellation.test.ts:48,68`, `videoExtendI2v.test.ts:388`, `provider-execution-routes.test.ts:71,176`, `agent-mode-runtime-contract.test.ts:136` 등) | `Bearer <seeded token>` 으로 교체 (감사 N12) |
+| `grokUrl`/`grokActualPort` 픽스처: `prompt-builder-contract.test.ts:262`, `grok-planner-adapter.test.ts:177-178`, `grokVideoAdapter.test.ts:39`, `video-download-cancellation.test.ts:48` | 격리 HOME 시드로 교체 |
 | `tests/grok-execution-parity.test.ts:79-80,252,259-260` | grok/grok-api 모두 origin `https://api.x.ai`, bearer만 다름으로 재작성 |
 | `tests/error-envelope-contract.test.ts:81,291` | 프록시 주소 픽스처 → fetch 스텁이 401/503 반환 |
 | `tests/models-endpoint-contract.test.ts:104,121,366-383` | `grokProxyState` 주입 케이스는 wp4에서 재작성; 이 레이어에서는 그대로 통과해야 함(grokLaneState 미변경) |
@@ -98,7 +107,7 @@ export async function fetchWithGrokAuth<R extends { status: number }>(
 ## 검증
 
 `npm run typecheck && npm run typecheck:tests && npm test` 전체. 추가로
-`node --experimental-strip-types --test tests/grok-direct-lane-contract.test.ts tests/grok-execution-parity.test.ts`.
+`node --experimental-test-module-mocks --import tsx --test tests/grok-direct-lane-contract.test.ts tests/grok-execution-parity.test.ts` (러너 플래그와 동일; strip-types 불가, 감사 B4).
 활성화 근거(C-ACTIVATION-GROUNDING-01): (b)는 fetch 스텁이 첫 호출에 401, 둘째에 200을 반환해 재시도 분기를 실제로 태운다.
 
 라이브 증거(선택, 과금 없음): 격리 HOME에 실제 `~/.progrok/auth.json`을 복사한 뒤 `GET /api/grok/status`가 `ready`와 모델 목록을 반환하는지. `expiresAt`을 과거로 조작해 로그에 refresh 1회가 찍히는지.

--- a/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
+++ b/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
@@ -63,7 +63,7 @@ export async function fetchWithGrokAuth<R extends { status: number; headers: Hea
 }
 ```
 
-`RouteRuntimeContext`에 `grokAuthHomeDir?: string`을 추가해 테스트가 격리 HOME을 주입한다
+`RuntimeContext`(lib/runtimeContext.ts:11; RouteRuntimeContext는 파생형)에 `grokAuthHomeDir?: string`을 추가해 테스트가 격리 HOME을 주입한다
 (`resolveGrokCredential`이 `getGrokAccessToken({ homeDir: ctx.grokAuthHomeDir })`로 전달).
 
 ## 파일 변경 지도

--- a/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
+++ b/devlog/_plan/260909_grok_native_oauth/020_wp3_direct_lane.md
@@ -1,0 +1,108 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, wp3, direct-lane]
+---
+
+# 020 — wp3: grok 레인 직접 호출 전환
+
+브랜치 `codex/grok-native-oauth-03-direct-lane`, base `codex/grok-native-oauth-02-xai-auth`.
+이 레이어가 끝나면 `grok` 레인의 모든 요청이 `https://api.x.ai`로 직접 나간다. 프록시
+슈퍼바이저와 `getGrokProxyUrl`은 파일로는 남되 프로덕션 호출자가 0이 된다(삭제는 wp4).
+클래스 C3.
+
+## 핵심 설계 (002 §2, §5 채택)
+
+`lib/grokRuntime.ts`를 재작성해 세 가지를 소유한다.
+
+```ts
+// lib/grokRuntime.ts (재작성, ~90줄). leaf: lib/xaiAuth.js 만 import.
+export type GrokCredential = { kind: "api-key"; key: string } | { kind: "oauth"; token: string };
+
+export function getGrokDirectBaseUrl(): string { return "https://api.x.ai"; }   // 유일한 상수원
+
+export function grokAuthHeaders(c: GrokCredential): Record<string, string> {
+  return { "Content-Type": "application/json", Authorization: `Bearer ${c.kind === "api-key" ? c.key : c.token}` };
+}
+
+/** 유일한 credential 해석 지점. */
+export async function resolveGrokCredential(ctx: RouteRuntimeContext, provider: "grok" | "grok-api",
+  opts?: { forceRefresh?: boolean; rejectedAccessToken?: string; signal?: AbortSignal }): Promise<GrokCredential> {
+  if (provider === "grok-api") {
+    const key = typeof ctx.xaiApiKey === "string" ? ctx.xaiApiKey.trim() : "";
+    if (!key) throw grokCredentialError("GROK_API_KEY_MISSING", 401, "Grok API key is required for grok-api");
+    return { kind: "api-key", key };
+  }
+  return { kind: "oauth", token: await getGrokAccessToken(opts) };   // GrokAuthError 그대로 전파
+}
+
+export function getGrokEndpoint(path: string, credential: GrokCredential) {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return { url: `${getGrokDirectBaseUrl()}${normalizedPath}`, headers: grokAuthHeaders(credential) };
+}
+
+/**
+ * 401 을 정확히 1회 refresh 후 재시도. grokFetchWithRetry 는 헤더를 다시 만들 수 없으므로 여기서만 처리(R6).
+ * doFetch 는 credential 을 받아 요청을 만든다. 이미지/비디오 시작처럼 재시도 금지 호출도 401 은 생성 전 거부라 안전.
+ */
+export async function fetchWithGrokAuth<R extends { status: number }>(
+  ctx: RouteRuntimeContext, provider: "grok" | "grok-api",
+  doFetch: (credential: GrokCredential) => Promise<R>, opts?: { signal?: AbortSignal },
+): Promise<R> {
+  const first = await resolveGrokCredential(ctx, provider, opts);
+  const res = await doFetch(first);
+  if (res.status !== 401 || first.kind !== "oauth") return res;
+  const second = await resolveGrokCredential(ctx, provider, { ...opts, forceRefresh: true, rejectedAccessToken: first.token });
+  return doFetch(second);
+}
+```
+
+`RouteRuntimeContext`에 `grokAuthHomeDir?: string`을 추가해 테스트가 격리 HOME을 주입한다
+(`resolveGrokCredential`이 `getGrokAccessToken({ homeDir: ctx.grokAuthHomeDir })`로 전달).
+
+## 파일 변경 지도
+
+| 경로 | 종류 | 변경 |
+|---|---|---|
+| `lib/grokRuntime.ts` | REWRITE | 위 코드. `getGrokProxyBaseUrl`/`getGrokProxyUrl`은 **wp4까지 남긴다**(routes/grok.ts 옛 코드 컴파일용) — 단 deprecated 주석 |
+| `lib/grokImageCore.ts:62-74` | MODIFY | `getGrokEndpoint(ctx, path, directApiKey?)` 삭제 → `grokRuntime`의 것을 re-export. `postGrokImages(ctx, payload, signal, path, credential: GrokCredential)` 시그니처 변경. 내부 fetch를 `fetchWithGrokAuth`로 감싸지 않고 credential을 받는 형태로 유지(재시도 정책은 호출자 소유) |
+| `lib/grokImageCore.ts:171-181` | MODIFY | 401/403 → `GROK_AUTH_FAILED` 매핑은 유지. `GrokAuthError`가 상위에서 던져지면 그 code 유지 |
+| `lib/grokVideoShared.ts:113-125` | MODIFY | `videoEndpoint` 본문 삭제 → `export { getGrokEndpoint as videoEndpoint } from "./grokRuntime.js"`. `GrokVideoOptions.directApiKey`(:59) → `credential: GrokCredential` |
+| `lib/grokImagePlanner.ts:207,283` | MODIFY | `directApiKey?: string` → `credential: GrokCredential`; :212, :310 호출 갱신 |
+| `lib/providers/adapters/grokOperations.ts:28,52,58-61,79,86,91-94` | MODIFY | 옵션 필드 교체; `trustedProxyOrigin` 3곳 제거(직결 URL은 공개 https) |
+| `lib/providers/adapters/grokMultimodeOperations.ts:48,98,101-104` | MODIFY | 동일 |
+| `lib/providers/adapters/grokExecution.ts:27,59,84,96` | MODIFY | `const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined` → `const credential = await resolveGrokCredential(ctx, activeProvider, { signal })`. 4곳 |
+| `lib/grokVideoAdapter.ts:247,282,398` | MODIFY | `options.directApiKey` → `options.credential` |
+| `lib/grokVideoPoll.ts:42,45,91` | MODIFY | 동일 |
+| `routes/video.ts:543,558` | MODIFY | `provider === "grok-api" ? ctx.xaiApiKey : undefined` → `await resolveGrokCredential(ctx, provider)` |
+| `lib/videoExtendI2vOperation.ts:68` | MODIFY | 동일 |
+| `routes/videoExtended.ts:69-70,206,341,435` | MODIFY | `videoProxyUrl` 삭제. 세 라우트가 `fetchWithGrokAuth(ctx, provider, (c) => fetch(getGrokEndpoint(path, c).url, ...))` 사용. **provider는 요청 body에서 읽되 기본 "grok"** (지금은 grok-api 사용자도 프록시로 새던 잠재 버그를 함께 고침) |
+| `lib/agentPlannerModel.ts:115` | MODIFY | `getGrokEndpoint(ctx, "/v1/chat/completions")` → `fetchWithGrokAuth(ctx, "grok", ...)` |
+| `lib/promptBuilder/router.ts:107-112` | MODIFY | `resolveGrokCredential(ctx, backend)`로 통일; grok도 자격증명 없으면 `unavailableBackendError("grok")` |
+| `routes/grok.ts` | REWRITE | probe token 제거. `fetchWithGrokAuth(ctx, "grok", (c) => fetch(getGrokEndpoint("/v1/models", c).url, {headers, signal}))`. `GrokAuthError.code === "GROK_AUTH_REQUIRED"` → `{status:"offline", reason:"login_required"}`, `GROK_AUTH_REFRESH_FAILED` → `{status:"error", reason}`. 응답 리터럴 4종 유지(R8) |
+| `lib/providers/execution/admission.ts:13-17` | MODIFY | `directKeyFailure`를 양 레인 대칭으로: grok은 `loadGrokCredentials()` null이면 `{status:401, code:"GROK_AUTH_REQUIRED"}` |
+| `lib/errors/providerMap.ts` | MODIFY | (wp2에서 추가한 두 코드가 여기서 실제 사용) |
+| `lib/runtimeContext.ts` | MODIFY | `grokAuthHomeDir?: string` 추가만. 프록시 필드 삭제는 wp4 |
+
+## 테스트 변경
+
+| 파일 | 변경 |
+|---|---|
+| `tests/_executionRouteHarness.ts:164` | `grokUrl` 픽스처 대신 격리 HOME + `auth.json` 작성 헬퍼 `seedGrokAuth(home, {accessToken, expiresAt})` 추가; `ctx.grokAuthHomeDir` 주입 |
+| `tests/_videoExecutionFixture.ts:97` 외 `Bearer dummy` 단정 5곳 | `Bearer <seeded token>` 으로 교체 |
+| `tests/grok-execution-parity.test.ts:79-80,252,259-260` | grok/grok-api 모두 origin `https://api.x.ai`, bearer만 다름으로 재작성 |
+| `tests/error-envelope-contract.test.ts:81,291` | 프록시 주소 픽스처 → fetch 스텁이 401/503 반환 |
+| `tests/models-endpoint-contract.test.ts:104,121,366-383` | `grokProxyState` 주입 케이스는 wp4에서 재작성; 이 레이어에서는 그대로 통과해야 함(grokLaneState 미변경) |
+| `tests/grok-direct-lane-contract.test.ts` | NEW: (a) 만료 토큰 → 사전 refresh 후 요청 헤더에 새 토큰, (b) 유효 토큰인데 upstream 401 → refresh 1회 + 재요청 1회, 두 번째 401은 `GROK_AUTH_REQUIRED`, (c) grok-api 는 401이어도 refresh 없음, (d) videoExtended 세 라우트가 Authorization 헤더를 실제로 싣는지 |
+
+## 검증
+
+`npm run typecheck && npm run typecheck:tests && npm test` 전체. 추가로
+`node --experimental-strip-types --test tests/grok-direct-lane-contract.test.ts tests/grok-execution-parity.test.ts`.
+활성화 근거(C-ACTIVATION-GROUNDING-01): (b)는 fetch 스텁이 첫 호출에 401, 둘째에 200을 반환해 재시도 분기를 실제로 태운다.
+
+라이브 증거(선택, 과금 없음): 격리 HOME에 실제 `~/.progrok/auth.json`을 복사한 뒤 `GET /api/grok/status`가 `ready`와 모델 목록을 반환하는지. `expiresAt`을 과거로 조작해 로그에 refresh 1회가 찍히는지.
+
+## 우회 경로
+
+`resolveGrokCredential`은 어댑터 입구의 조기 경고다. `getGrokEndpoint`를 직접 import해 credential을 임의로 만들면 우회 가능. 최종 계층: 없음(xAI 서버의 401).

--- a/devlog/_plan/260909_grok_native_oauth/030_wp4_remove_progrok.md
+++ b/devlog/_plan/260909_grok_native_oauth/030_wp4_remove_progrok.md
@@ -16,7 +16,7 @@ tags: [ima2-gen, devlog, grok, progrok, wp4, removal]
 | `lib/grokProxyLauncher.ts` | 003 §1-1. import는 `server.ts:18`, `lib/runtimeContext.ts:4`뿐 |
 | `vendor/progrok-0.2.0.tgz` | 003 §1-14 |
 | `tests/grok-proxy-supervisor-contract.test.ts`, `grok-proxy-restart.test.ts`, `grok-proxy-launcher.test.ts`, `grok-command-login-contract.test.ts` | 003 §2-1 |
-| `tests/grok-advertise-liveness-contract.test.ts` | `backend` 계약(42-50)은 새 `tests/advertise-payload-contract.test.ts`로 이동 |
+| `tests/grok-advertise-liveness-contract.test.ts` | 새 `tests/advertise-payload-contract.test.ts`로 대체: `backend` 계약(42-50) + **grok auth 두 케이스**(격리 HOME에 auth.json 있음→`"oauth"`, 없음→`"none"`). 이 파일이 `buildAdvertisePayload`를 부르는 유일한 테스트라 계약이 비면 안 된다(감사 B5) |
 | `scripts/paired-generated-paths.txt:9` | `lib/grokProxyLauncher.js` 행 |
 
 ## 수정
@@ -54,7 +54,7 @@ tags: [ima2-gen, devlog, grok, progrok, wp4, removal]
 -  const grokLive = ctx.grokProxyLive === true;
  ...
 -    grok: { configuredPort, actualPort, url, live: grokLive },
-+    grok: { auth: loadGrokCredentials() ? "oauth" : "none" },
++    grok: { auth: loadGrokCredentials(ctx.grokAuthHomeDir) ? "oauth" : "none" },   // homeDir 주입: 테스트가 개발자 ~/.progrok 에 의존하지 않도록 (감사 B5)
 ```
 
 `bin/commands/service.ts:139-151`: `grok.live === false` 경고 → `grok.auth === "none"`이면 "Grok is not logged in. Run ima2 grok login." 안내.
@@ -84,10 +84,10 @@ function grokLaneState(): LaneState {
 
 `routes/quota.ts:118-127`: 경로 상수는 `grokAuthFilePath()`로, 라벨 `progrok:auth-json` → `ima2:grok-auth-json`.
 
-`bin/lib/doctor-runtime.ts:7`: `"progrok/package.json"` 제거. `bin/lib/doctor-providers.ts:49-55`: 경로를 `grokAuthFilePath()`로, 문구 "no ~/.progrok or ~/.grok auth file" 유지(경로 자체는 안 바뀜).
+`bin/lib/doctor-runtime.ts:7`: `"progrok/package.json"` 제거. `bin/lib/doctor-providers.ts:49-55`: 첫 원소를 `grokAuthFilePath()`로, 두 번째 `~/.grok/auth.json`은 **유지**(quota가 여전히 읽는 xAI CLI 파일; 스키마가 달라 `lib/xaiAuth.ts`의 소스로는 쓰지 않고 절대 쓰지 않는다 — 감사 N7). 문구 유지.
 
 `bin/commands/grok.ts` REWRITE (R11): progrok spawn 제거. 서브커맨드:
-- `login [--device-code]`: 서버가 떠 있으면 `POST /api/auth/switch {provider:"grok"}` 후 폴링(기존 GUI 경로 재사용); 서버가 없으면 `routes/auth.ts`의 device-code 로직을 `lib/xaiDeviceLogin.ts`로 추출해 직접 실행. 이 추출은 이 WP의 부수 리팩터(routes/auth.ts:79-141 → lib).
+- `login`: 서버가 떠 있으면 `POST /api/auth/switch {provider:"grok"}` 후 `GET /api/auth/switch/:id` 폴링(기존 GUI 경로 재사용). 서버가 없으면 `lib/xaiDeviceLogin.ts`에 **stateless 함수 하나를 새로 쓴다**(discovery → device_authorization POST → 토큰 폴링 → `saveGrokCredentials`). `routes/auth.ts:76-142`는 `sessions` Map/`cleanup()`에 얽혀 있어 추출하지 않고 그대로 둔다(감사 검증 6). 공유는 `lib/xaiAuth.ts`의 상수와 `saveGrokCredentials`뿐.
 - `status`: `loadGrokCredentials()` 요약(email, expiresAt 상대시간, refresh 가능 여부) + `--probe`면 `/v1/models` 호출.
 - `logout`: `clearGrokCredentials()`.
 - `models`/`proxy` 제거. HELP 갱신.

--- a/devlog/_plan/260909_grok_native_oauth/030_wp4_remove_progrok.md
+++ b/devlog/_plan/260909_grok_native_oauth/030_wp4_remove_progrok.md
@@ -1,0 +1,119 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, progrok, wp4, removal]
+---
+
+# 030 — wp4: progrok 슈퍼바이저·의존성 제거, 네이티브 CLI, readiness 재정의
+
+브랜치 `codex/grok-native-oauth-04-remove-progrok`, base `codex/grok-native-oauth-03-direct-lane`.
+클래스 C4(의존성 제거 + 릴리스 표면 + 패키징). 003_removal_blast_radius.md가 근거.
+
+## 삭제
+
+| 경로 | 근거 |
+|---|---|
+| `lib/grokProxyLauncher.ts` | 003 §1-1. import는 `server.ts:18`, `lib/runtimeContext.ts:4`뿐 |
+| `vendor/progrok-0.2.0.tgz` | 003 §1-14 |
+| `tests/grok-proxy-supervisor-contract.test.ts`, `grok-proxy-restart.test.ts`, `grok-proxy-launcher.test.ts`, `grok-command-login-contract.test.ts` | 003 §2-1 |
+| `tests/grok-advertise-liveness-contract.test.ts` | `backend` 계약(42-50)은 새 `tests/advertise-payload-contract.test.ts`로 이동 |
+| `scripts/paired-generated-paths.txt:9` | `lib/grokProxyLauncher.js` 행 |
+
+## 수정
+
+`lib/grokRuntime.ts`: `getGrokProxyBaseUrl`/`getGrokProxyUrl`과 `DEFAULT_GROK_PROXY_*` 삭제. wp3 이후 호출자 0 확인 후.
+
+`server.ts` (003 §1-3):
+
+```diff
+-import { startGrokProxy } from "./lib/grokProxyLauncher.js";
+ ...
+-  markGrokProxyPort: (info?: { url?: string; port?: number }) => void;
+ ...
+-  const grokPort = config.grokProvider.proxyPort;
+ ...
+-    grokPort,
+-    grokActualPort: grokPort,
+-    grokUrl: `http://${config.grokProvider.proxyHost}:${grokPort}/v1`,
+ ...
+-    markGrokProxyPort: ({ url, port } = {}) => { ... },
+ ...
+-  const grokChild = ctx.config.grokProvider.autoStart ? await startGrokProxy({ ... }) : null;
+-  ctx.grokProxy = grokChild ?? undefined;
+ ...
+-  try { grokChild?.stop?.(); } catch {}
+-  try { grokChild?.kill?.(); } catch {}
+ ...
+-  console.log(`Provider policy: ... Grok proxy port ${ctx.grokActualPort || ctx.grokPort}.`);
++  console.log(`Provider policy: GPT OAuth, API-key Responses, and Grok (xAI OAuth or API key) providers. GPT OAuth proxy port ${ctx.oauthPort}.`);
+```
+
+`buildAdvertisePayload`(`server.ts:306-333`) — R9:
+
+```diff
+-  const grokLive = ctx.grokProxyLive === true;
+ ...
+-    grok: { configuredPort, actualPort, url, live: grokLive },
++    grok: { auth: loadGrokCredentials() ? "oauth" : "none" },
+```
+
+`bin/commands/service.ts:139-151`: `grok.live === false` 경고 → `grok.auth === "none"`이면 "Grok is not logged in. Run ima2 grok login." 안내.
+
+`lib/runtimeContext.ts`: `grokActualPort`/`grokPort`/`grokUrl`/`grokProxy`/`grokProxyLive` 필드(:22-28), `GrokProxyHandle` import(:4), `requireRuntimeContext` 기본값(:116-124), `createTestRuntimeContext`(:197-199), 주석(:16-19) 정리.
+
+`config.ts:378-387`: `proxyPort`/`proxyHost`/`autoStart`/`restartDelayMs`/`restartMaxAttempts`/`restartMaxDelayMs`/`restartHealthyMs` 7키 삭제. `IMA2_NO_GROK_PROXY`, `IMA2_GROK_PROXY_*`, `IMA2_GROK_RESTART_*` env는 읽지 않게 됨(문서에 deprecated 표기는 wp5).
+
+`lib/providers/registry.ts:73`: `{ kind: "oauth-proxy", envVars: [...], configKey: "grokProvider" }` → `{ kind: "oauth", authFile: "~/.progrok/auth.json" }`. `lib/providers/types.ts`의 credential union에 `kind: "oauth"` 추가. `node scripts/generate-provider-types.mjs` 재생성.
+
+`routes/models.ts:130,140-161` `grokLaneState`:
+
+```ts
+function grokLaneState(): LaneState {
+  const creds = loadGrokCredentials();
+  if (!creds) return { status: "disconnected", reason: "Grok login required" };
+  if (creds.expiresAt !== undefined && Date.now() >= creds.expiresAt && !creds.refreshToken)
+    return { status: "disconnected", reason: "Grok session expired" };
+  return { status: "ready" };
+}
+```
+`UNPROBED_GROK_REASON` 삭제.
+
+`routes/health.ts:20-24`: `grok: { configuredPort, actualPort, url }` → `grok: { auth: "oauth" | "none" }`.
+
+`routes/auth.ts:258`: `startGrokDeviceCode(() => ctx?.grokProxy?.notifyCredentialsChanged())` → `startGrokDeviceCode()`; 콜백 파라미터 제거.
+
+`routes/quota.ts:118-127`: 경로 상수는 `grokAuthFilePath()`로, 라벨 `progrok:auth-json` → `ima2:grok-auth-json`.
+
+`bin/lib/doctor-runtime.ts:7`: `"progrok/package.json"` 제거. `bin/lib/doctor-providers.ts:49-55`: 경로를 `grokAuthFilePath()`로, 문구 "no ~/.progrok or ~/.grok auth file" 유지(경로 자체는 안 바뀜).
+
+`bin/commands/grok.ts` REWRITE (R11): progrok spawn 제거. 서브커맨드:
+- `login [--device-code]`: 서버가 떠 있으면 `POST /api/auth/switch {provider:"grok"}` 후 폴링(기존 GUI 경로 재사용); 서버가 없으면 `routes/auth.ts`의 device-code 로직을 `lib/xaiDeviceLogin.ts`로 추출해 직접 실행. 이 추출은 이 WP의 부수 리팩터(routes/auth.ts:79-141 → lib).
+- `status`: `loadGrokCredentials()` 요약(email, expiresAt 상대시간, refresh 가능 여부) + `--probe`면 `/v1/models` 호출.
+- `logout`: `clearGrokCredentials()`.
+- `models`/`proxy` 제거. HELP 갱신.
+
+`package.json`: `dependencies.progrok`(:102), `bundleDependencies`의 `"progrok"`(:112) 삭제 → `npm install --package-lock-only`로 lock 재생성(`check-install-policy.mjs:67-71` 게이트).
+
+`nix/node-modules.nix:21,29-30` progrok 참조 삭제, `flake.nix:18`·`Dockerfile:12` 주석 갱신, `scripts/qa-grok-video.mjs:11,181` 문구 갱신.
+
+`.github/workflows/ci.yml:108-109` "CLI smoke (grok --help)" → `node bin/ima2.js grok status --json`(로그인 없어도 exit 0으로 `{auth:"none"}` 출력하도록 설계). `provider-canary.yml:34-35` `CANARY_GROK_MODELS_URL`/`CANARY_GROK_TOKEN`은 그대로 두되 canary 스크립트가 URL 기본값을 `https://api.x.ai/v1/models`로 쓰는지 확인.
+
+`tests/package-install-smoke.mjs:141,154,184,218,223,238-239`: progrok bin/help 단정 삭제, `ima2 grok status` 단정으로 교체. `tests/release-pipeline-contract.test.ts:215,218` 픽스처 `["openai-oauth"]`. `tests/cli-commands.test.js:357-365` 새 HELP 문구. `tests/models-endpoint-contract.test.ts` `grokProxyState` 케이스 → 격리 HOME auth.json 유무 케이스. `tests/runtime-context-normalize.test.ts:25,62-65`, `tests/agent-mode-runtime-contract.test.ts:101,135,514,603`, `tests/e2e-app-environment.test.ts:36-39,66`, `tests/j6-isolation-preflight.test.mjs:99,222`, `tests/history-tombstone.test.ts:69`, `ui/e2e/fixtures/appIsolation.ts:32-33`, `ui/e2e/fixtures/appServer.ts:79,138-139,318`, `ui/e2e/fixture-isolation.spec.ts:34`: `IMA2_NO_GROK_PROXY`/포트 픽스처 제거.
+
+## 생성물 게이트 (반드시 순서대로)
+
+1. `node scripts/generate-provider-types.mjs`
+2. `node scripts/classify-tests.mjs` (docs/migration/runtime-test-inventory.md)
+3. `node scripts/refresh-structure-line-counts.mjs` + `structure/01-file-function-map.md`의 삭제 파일 행 수동 제거(:292 grokProxyLauncher, :137 grok.ts 설명 갱신, :68)
+4. `npm install --package-lock-only` → `npm run test:install-policy`
+
+## 검증
+
+로컬: `npm run typecheck && npm run typecheck:tests && npm test && npm run test:inventory && npm run lint:pkg && npm run test:package-install`.
+`rg -n progrok lib routes bin server.ts config.ts package.json` → `lib/xaiAuth.ts`의 경로 상수 주석만.
+격리 HOME 부팅: `HOME=$TMP node --import tsx server.ts` → `/api/health` `grok.auth === "none"`; auth.json 복사 후 재기동 → `"oauth"`; `GET /api/grok/status` → ready.
+호스팅: PR CI(pr-fast) 후행 추적 + **`gh workflow run ci.yml -f sha=<head>`** 로 package smoke·Windows 레인까지 확인(003 §5-2).
+
+## 우회 경로
+
+없음(제거 작업). 잔존 위험은 외부 도구가 `~/.ima2/server.json`의 `grok.url`을 읽던 경우 — 003 §1-4 기준 그런 소비자는 저장소 안에 없다.

--- a/devlog/_plan/260909_grok_native_oauth/040_wp5_docs_sot.md
+++ b/devlog/_plan/260909_grok_native_oauth/040_wp5_docs_sot.md
@@ -1,0 +1,57 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, progrok, wp5, docs, sot]
+---
+
+# 040 — wp5: SoT·문서·i18n 동기화, 선행 유닛 아카이브, 최종 CI
+
+브랜치 `codex/grok-native-oauth-05-docs`, base `codex/grok-native-oauth-04-remove-progrok`.
+클래스 C2(문서) + 최종 검증. 003 §3, §6이 전수 목록이다.
+
+## structure/ (SoT)
+
+| 파일:줄 | 현재 | 변경 |
+|---|---|---|
+| `structure/06-infra-operations.md:61` | Mermaid `SRV --> GROK["progrok<br/>default port 18645"]` | 노드 삭제, `SRV --> XAI["api.x.ai<br/>OAuth bearer / API key"]` |
+| `:77` | bundled dependencies `progrok, patched openai-oauth, zod` | `patched openai-oauth, zod` |
+| `:168-170` | env 표 `IMA2_GROK_PROXY_HOST/_PORT`, `IMA2_NO_GROK_PROXY` | 삭제 + "3.16에서 제거됨, 무시됨" 한 줄 |
+| `:213` | `provider: "grok"` uses bundled progrok | "`grok`는 `~/.progrok/auth.json`의 xAI OAuth 세션으로 api.x.ai를 직접 호출한다. xAI는 이 경로를 공식 문서화하지 않았다(004 §0)" |
+| `:374` 변경 이력 | — | 2026-09-09 항목 추가 |
+| `structure/00-structure-hub.md:13,21,38,59` | progrok 언급 4곳 | `lib/xaiAuth.ts`/`lib/grokRuntime.ts`로 재서술, Mermaid `API --> XAI` |
+| `structure/02-command-reference.md:58,134,143,192` | `ima2 grok login/status/models/proxy`, "bundled progrok OAuth" | `login/status/logout`, "xAI OAuth 세션(device code)" |
+| `structure/01-file-function-map.md` | :292 grokProxyLauncher 행, :293 grokRuntime 설명, :137 grok.ts, :68 | 행 삭제/설명 갱신, `lib/xaiAuth.ts`·`lib/xaiDeviceLogin.ts` 행 추가, 라인수 스크립트 재실행 |
+| `structure/07-devlog-map.md` | — | 이 유닛 등재 |
+
+## 사용자 문서
+
+`README.md:173-174,355-357`, `docs/CLI.md:18,116,165-168,468`, `docs/API.md:65,155,166,397,882-883`,
+`docs/README.ko.md:135-136,266-268`, zh-CN/zh-TW 6종 동일 위치, `skills/ima2/SKILL.md:88`,
+`AGENTS.md:28` (`- Grok: xAI OAuth (device code) 또는 API key, api.x.ai 직접 호출`).
+`docs/grok-video-i2v-*` 9파일은 과거 계획 문서라 손대지 않는다(003 §3-3).
+
+README/docs에 "xAI 미문서 경로" 위험 문단 1개를 추가한다(000_plan 알려진 위험 1).
+
+## site/ (Astro)
+
+`site/src/pages/docs/reference/config.astro:45-47`(+ko) env 3행 삭제,
+`concepts/architecture.astro`, `concepts/providers.astro`, `reference/api.astro`, `reference/cli.astro`, `docs/index.astro` (각 en+ko), `site/src/i18n/strings.ts` 4곳.
+`cd site && npm run build`로 확인.
+
+## UI i18n (4 로케일)
+
+`ui/src/components/ResultMetadataModal.tsx:23` `"Grok OAuth / progrok"` → `"Grok OAuth"`.
+en/ko/zh-Hans/zh-Hant 각각: `readiness.grokApiBody`(360), `provider.grokOffline`(740, "Grok 로그인이 필요합니다"), `provider.grokOfflineHint`(743), `grokManagedByIma2`(744), `grokCompatBody`(748), `grokEyebrow`(1326, "xAI OAuth"), `grokBody`(1328), `unsupportedHelp`(1391), 1640.
+`tests/i18n-dictionary-contract.test.ts`가 키 집합을 동결하므로 키 이름은 유지하고 값만 바꾼다.
+
+## 선행 유닛 아카이브 (003 §4-3)
+
+`git mv devlog/_plan/260819c_grok_proxy_supervision devlog/_fin/260819_grok_proxy_supervision`.
+`900_superseded.md` 추가: 054c729f가 WP2~WP4를 실제 구현했다는 사실(README:26의 "구현 미착수" 오기 정정), 이 유닛이 그 구현을 통째로 제거한다는 사실, 경로.
+`devlog/_plan/README.md:26` 행 삭제, `_fin` 이동 기록 추가, 이 유닛을 Active Lane에 등재.
+
+## 검증
+
+`npm run typecheck && npm run typecheck:tests && npm test && npm run test:inventory && npm run docs:runtime:check && node scripts/refresh-structure-line-counts.mjs --check && (cd ui && npm run build) && (cd site && npm run build)`.
+`rg -n 'progrok|18645|IMA2_GROK_PROXY|IMA2_NO_GROK_PROXY' README.md docs structure site skills AGENTS.md ui/src --glob '!docs/grok-video-i2v-*' --glob '!devlog/**'` → 0건.
+최종: 050_verification.md의 스택 CI 절차.

--- a/devlog/_plan/260909_grok_native_oauth/050_verification.md
+++ b/devlog/_plan/260909_grok_native_oauth/050_verification.md
@@ -1,0 +1,54 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, verification, ci, stacked-pr]
+---
+
+# 050 — 검증과 전달 절차
+
+## 스택 규약
+
+수동 체인(DEV-STACK-06). GitHub native stack 사용 안 함. 각 PR body에 스택 맵 표
+(DEV-STACK-03). 하위 레이어를 고치면 `git rebase --update-refs`로 상위까지 cascade 후
+`--force-with-lease` (DEV-STACK-02), 그리고 `git merge-base --is-ancestor <lower> <upper>`로 확인.
+
+| # | 브랜치 | base | PR |
+|---|---|---|---|
+| 1 | `codex/grok-native-oauth-01-roadmap` | dev | 문서만 |
+| 2 | `codex/grok-native-oauth-02-xai-auth` | 01 | lib/xaiAuth.ts + 테스트 |
+| 3 | `codex/grok-native-oauth-03-direct-lane` | 02 | 레인 전환 |
+| 4 | `codex/grok-native-oauth-04-remove-progrok` | 03 | 제거·CLI·readiness |
+| 5 | `codex/grok-native-oauth-05-docs` | 04 | SoT·문서 |
+
+push와 PR 생성은 사용자가 이 세션에서 "작업하면서 올리고"로 승인했다. merge는 승인되지 않았다.
+
+## 레이어별 C 게이트
+
+모든 레이어 공통: `npm run typecheck`, `npm run typecheck:tests`, `npm test`, `npm run test:inventory`,
+`node scripts/refresh-structure-line-counts.mjs --check`, `node scripts/generate-provider-types.mjs --check`.
+각 명령의 exit code와 tail을 `cxc receipt test`로 남긴다.
+
+| WP | 추가 게이트 |
+|---|---|
+| wp1 | `scripts/check-devlog-citations.mjs` (있으면), 문서 링크 존재 확인 |
+| wp2 | `tests/xai-auth-contract.test.ts` 15 시나리오 전부, 0600 퍼미션 단정 |
+| wp3 | `tests/grok-direct-lane-contract.test.ts`, `grok-execution-parity`; 격리 HOME 라이브 `/api/grok/status` |
+| wp4 | `npm run lint:pkg`, `npm run test:package-install`, `npm run test:install-policy`; `rg progrok` 0건; `gh workflow run ci.yml -f sha=<head>` |
+| wp5 | `cd ui && npm run build`, `cd site && npm run build`; 문서 rg 0건 |
+
+## CI 후행 추적
+
+PR마다 pr-fast.yml이 자동으로 돈다. 중간 레이어의 실패는 진단용이고, 최종 판정은
+스택 top(05) head SHA의 pr-fast `gate` job success + 같은 SHA에 `workflow_dispatch`한 ci.yml
+전 job success다. skipped/cancelled는 통과가 아니다.
+
+`gh pr checks <n> --watch`, `gh run list --commit <sha>`, `gh run view <id> --json jobs`로 job 단위로 기록한다.
+
+## 최종 증거 형식 (D)
+
+- 5개 PR URL과 head SHA, base 관계
+- 최종 head의 pr-fast run id + ci.yml dispatch run id, 각 job conclusion
+- 로컬 게이트 5개 명령 exit code
+- `rg progrok` 결과
+- 격리 HOME 부팅 로그(refresh 1회 발생 라인)
+- OpenCodex 이슈 번호 4개(000_plan 표 갱신)

--- a/devlog/_plan/260909_grok_native_oauth/README.md
+++ b/devlog/_plan/260909_grok_native_oauth/README.md
@@ -1,0 +1,24 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, progrok]
+---
+
+# 260909_grok_native_oauth
+
+Grok 레인을 progrok 자식 프로세스 프록시에서 네이티브 xAI OAuth 직접 호출로 전환한다.
+
+| 문서 | 내용 |
+|---|---|
+| 000_plan.md | 결정 R1~R12, WP 지도, 위험, 범위 |
+| 001_opencodex_port_spec.md | OpenCodex xai.ts 이식 사양, 결함 감사 D1~D9 |
+| 002_callsite_inventory.md | 프록시 도달 경로 전수 |
+| 003_removal_blast_radius.md | 제거 blast radius |
+| 004_xai_docs_aside_research.md | docs.x.ai·discovery·progrok 원본 조사 |
+| 010_wp2_xai_auth.md | lib/xaiAuth.ts |
+| 020_wp3_direct_lane.md | 레인 전환 |
+| 030_wp4_remove_progrok.md | 제거·CLI·readiness |
+| 040_wp5_docs_sot.md | SoT·문서 |
+| 050_verification.md | 게이트·스택·증거 |
+
+선행: `260819c_grok_proxy_supervision` (wp5에서 _fin으로 아카이브, superseded).

--- a/devlog/_plan/README.md
+++ b/devlog/_plan/README.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-23
-updated: 2026-09-07
+updated: 2026-09-09
 tags: [ima2-gen, devlog, roadmap]
 aliases: [ima2 active plan, image_gen current roadmap, ima2 개발계획]
 ---
@@ -25,7 +25,8 @@ Deferred / 미래 항목은 `_plan/` 직속이 아니라 `_plan/_future/`에 둔
 | 경로 | 상태 |
 |---|---|
 | `260908_xai_imagine_spec_resync/` | v3.15.1로 배포 완료. xAI ref2v 상한 7->14, 모델별 ref2v 길이, 연장 1-15s, 이미지 편집 5장, 날짜 별칭, 오디오 단독 ref2v를 서버·UI·CLI·문서에 반영. GUI에 보이스 선택과 영상 편집 버튼 추가. 남은 것: 컴포저 드롭에서 편집으로 들어가는 흐름(결과 카드로 대체 가능). 배포 기록은 070_release_v3151.md. |
-| `260819c_grok_proxy_supervision/` | 조사 + 로드맵 완료 (000-030), 구현 미착수. Grok 프록시 수명주기 재설계 — ensure 진입점, 로그인 재기동, 프로브 기반 상태. |
+| `260909_grok_native_oauth/` | wp1 로드맵 완료(000~050, 감사 PASS). progrok 자식 프로세스 프록시를 걷어내고 grok 레인이 xAI OAuth로 api.x.ai를 직접 호출. wp2 xaiAuth 코어 → wp3 레인 전환 → wp4 제거·CLI → wp5 SoT/문서. 수동 체인 stacked PR, base dev. |
+| `260819c_grok_proxy_supervision/` | WP2~WP4는 054c729f로 이미 구현됨(이 표의 이전 "구현 미착수" 서술은 오기). `260909_grok_native_oauth`가 그 구현물을 통째로 제거하므로 superseded. wp5에서 `_fin/260819_grok_proxy_supervision`으로 아카이브. |
 
 ## 일정이 있는 후속 항목
 

--- a/structure/07-devlog-map.md
+++ b/structure/07-devlog-map.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-08
-updated: 2026-09-02
+updated: 2026-09-09
 tags: [ima2-gen, structure-docs, devlog, roadmap]
 ---
 
@@ -124,7 +124,8 @@ is empty again; GitHub parity and CI receipts live in the archived closeout.
 
 | Unit | Status | Open issue |
 |---|---|---|
-| `260819c_grok_proxy_supervision/` | Research + roadmap (000-030) complete. Implementation pending. | — |
+| `260909_grok_native_oauth/` | Roadmap (000-050) complete, audit PASS. Replace the progrok child-process proxy with native xAI OAuth on the grok lane; wp2-wp5 pending as a manual PR chain. | — |
+| `260819c_grok_proxy_supervision/` | WP2-WP4 landed in 054c729f. Superseded by `260909_grok_native_oauth`; archive to `_fin` in its wp5. | — |
 | `260902_studio_surfaces/` | NovelAI dual-prompt UI, configurable Prompt Builder backend, Canvas vectorize entry, docs upgrade, and release train. | — |
 
 Open issue #150 (Provider Adapter v1 RFC) is tracked in `_plan/README.md` but


### PR DESCRIPTION
Docs-only bottom layer of the Grok native-OAuth stack. It adds the implementation unit `devlog/_plan/260909_grok_native_oauth/` (research 000–004, diff-level decade docs 010–050) and registers it in the plan hub and devlog map. No production source changes.

**What it decides.** The `grok` lane stops depending on the bundled progrok child-process proxy and calls `https://api.x.ai` directly with the xAI OAuth token already stored in `~/.progrok/auth.json`, unified with the `grok-api` path. progrok today only does two things for ima2 (2-minute-skew refresh and bearer injection); device-code login and quota already bypass it. Decisions R1–R12 are in `000_plan.md`, including keeping the credential file byte-compatible (no re-login), single-flight refresh, and one 401→refresh→retry hook.

**Evidence.** Three opus-5 read-only explorers (OpenCodex `xai.ts` port spec + defect audit, proxy call-site inventory, removal blast radius) and one Aside browser run over all 183 docs.x.ai pages plus the live OIDC discovery document. An independent audit round found six blockers that are folded in (`b98f59d0`); round two passed.

Four defects found in OpenCodex's `src/oauth/xai.ts` during the port review were filed upstream: lidge-jun/opencodex#4045 #4046 #4047 #4048.

**Stack** (merge bottom-up):
| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 5 | (next) | SoT docs, i18n, archive | docs consistency |
| 4 | (next) | remove progrok, native CLI, readiness | packaging, CI smoke |
| 3 | (next) | grok lane direct api.x.ai | credential resolution, 401 hook |
| 2 | (next) | lib/xaiAuth.ts | token store, refresh, negative cases |
| 1 | this | roadmap ← you are here | plan soundness only |

Validation: `node scripts/check-devlog-citations.mjs`, `node scripts/refresh-structure-line-counts.mjs --check`, `node scripts/generate-provider-types.mjs --check`, `npm run test:inventory` all exit 0. Not run: product typecheck/tests (no source change).
