### PR TITLE
feat(grok): call api.x.ai directly with the stored xAI OAuth session [stack 3/5]

### DIFF
--- a/devlog/_plan/260909_grok_native_oauth/evidence/wp3-live-refresh.txt
+++ b/devlog/_plan/260909_grok_native_oauth/evidence/wp3-live-refresh.txt
@@ -1,0 +1,6 @@
+before expiresAt 1788858729834 expired: true
+fetch https://auth.x.ai/oauth2/token POST
+token refreshed: true same across 3 concurrent: true
+after expiresAt 1788912601531 valid: true refreshToken rotated: true
+token fetch calls: 1
+GET /v1/models 200 imagine models: grok-imagine-image,grok-imagine-image-2.0,grok-imagine-image-quality,grok-imagine-video,grok-imagine-video-1.5

--- a/lib/agentPlannerModel.ts
+++ b/lib/agentPlannerModel.ts
@@ -4,7 +4,8 @@ import { formatToolManifestForPrompt } from "./agentToolManifest.js";
 import { getAgentSession } from "./agentStore.js";
 import { errInfo } from "./errInfo.js";
 import { logEvent } from "./logger.js";
-import { getGrokEndpoint, getPlannerConfig } from "./grokImageCore.js";
+import { getPlannerConfig } from "./grokImageCore.js";
+import { fetchWithGrokAuth, getGrokEndpoint } from "./grokRuntime.js";
 import { waitForOAuthReady } from "./oauthProxy/runtime.js";
 import { requireRuntimeContext, type RouteRuntimeContext } from "./runtimeContext.js";
 import type { AgentGenerationPlan, AgentGenerationSettings } from "./agentTypes.js";
@@ -112,24 +113,24 @@ async function requestGrokPlan(
   userPrompt: string,
   signal: AbortSignal,
 ): Promise<string> {
-  const { url, headers } = getGrokEndpoint(ctx, "/v1/chat/completions");
   const planner = getPlannerConfig(ctx);
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    signal,
-    body: JSON.stringify({
-      model: planner.model,
-      stream: false,
-      messages: [
-        { role: "system", content: developerPrompt },
-        { role: "user", content: userPrompt },
-      ],
-    }),
+  const body = JSON.stringify({
+    model: planner.model,
+    stream: false,
+    messages: [
+      { role: "system", content: developerPrompt },
+      { role: "user", content: userPrompt },
+    ],
   });
+  // The agent planner only ever runs on the OAuth `grok` lane (the caller branches on
+  // settings.provider === "grok"), so a 401 here means the session needs a refresh.
+  const res = await fetchWithGrokAuth(ctx, "grok", (credential) => {
+    const endpoint = getGrokEndpoint("/v1/chat/completions", credential);
+    return fetch(endpoint.url, { method: "POST", headers: endpoint.headers, signal, body });
+  }, { signal });
   if (!res.ok) throw plannerHttpError("grok", res.status);
-  const body = await res.json() as ChatCompletionsBody;
-  return typeof body.choices?.[0]?.message?.content === "string" ? body.choices[0].message.content : "";
+  const parsed = await res.json() as ChatCompletionsBody;
+  return typeof parsed.choices?.[0]?.message?.content === "string" ? parsed.choices[0].message.content : "";
 }
 
 async function requestResponsesPlan(

--- a/lib/errors/providerMap.ts
+++ b/lib/errors/providerMap.ts
@@ -74,6 +74,9 @@ export const PROVIDER_ERROR_MAP = {
   // The refresh could not complete (network, 5xx, 429 budget exhausted); the
   // stored session is kept and a later attempt may succeed.
   GROK_AUTH_REFRESH_FAILED: "NETWORK_FAILURE",
+  // A Grok transport call was made without resolving a credential first. Programming
+  // error at the call site, never a user-facing auth state.
+  GROK_CREDENTIAL_UNRESOLVED: "INTERNAL_STATE_ERROR",
   GROK_BAD_REQUEST: "CAPABILITY_UNSUPPORTED",
   GROK_EMPTY_RESPONSE: "INTERNAL_STATE_ERROR",
   GROK_IMAGE_DOWNLOAD_FAILED: "NETWORK_FAILURE",

--- a/lib/grokImageCore.ts
+++ b/lib/grokImageCore.ts
@@ -1,8 +1,10 @@
 import type { RouteRuntimeContext } from "./runtimeContext.js";
 import { mapSizeToGrokImageParams } from "./grokSizeMapper.js";
 import { detectImageMimeFromB64 } from "./refs.js";
-import { getGrokProxyUrl } from "./grokRuntime.js";
+import { getGrokEndpoint, type GrokCredential } from "./grokRuntime.js";
 export { downloadGrokImageUrl } from "./grokImageDownload.js";
+export { getGrokEndpoint } from "./grokRuntime.js";
+export type { GrokCredential } from "./grokRuntime.js";
 import { DEFAULT_GROK_PLANNER_MODEL } from "../config.js";
 
 export interface GrokImageResponse {
@@ -57,20 +59,6 @@ export interface GrokReferenceImage {
   url?: string;
   declaredMime?: string | null;
   detectedMime?: string | null;
-}
-
-export function getGrokEndpoint(ctx: RouteRuntimeContext, path = "/v1/images/generations", directApiKey?: string): { url: string; headers: Record<string, string> } {
-  if (directApiKey) {
-    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-    return {
-      url: `https://api.x.ai${normalizedPath}`,
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${directApiKey}` },
-    };
-  }
-  return {
-    url: getGrokProxyUrl(ctx, path),
-    headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" },
-  };
 }
 
 export function getGrokTimeout(ctx: RouteRuntimeContext): number {
@@ -146,15 +134,19 @@ export function extractResponsesText(response: GrokResponsesResponse): string {
  * origin already generated and billed, and no idempotency key exists to deduplicate it.
  * Retrying would charge twice.
  * See devlog/_plan/260812_navrail_grok_autotag/020_grok_upstream_retry.md.
+ *
+ * A 401, by contrast, is rejected before anything is generated, so the caller may resolve a
+ * fresh credential and call this once more (lib/grokRuntime.ts fetchWithGrokAuth).
  */
 export async function postGrokImages(
   ctx: RouteRuntimeContext,
   payload: Record<string, unknown>,
   signal?: AbortSignal,
   path = "/v1/images/generations",
-  directApiKey?: string,
+  credential?: GrokCredential,
 ): Promise<GrokImageResponse> {
-  const { url, headers } = getGrokEndpoint(ctx, path, directApiKey);
+  if (!credential) throw grokError("Grok credential was not resolved before the request", 500, "GROK_CREDENTIAL_UNRESOLVED");
+  const { url, headers } = getGrokEndpoint(path, credential);
   const timeoutMs = getGrokTimeout(ctx);
 
   const { combinedSignal, timer } = withTimeoutSignal(signal, timeoutMs);

--- a/lib/grokImagePlanner.ts
+++ b/lib/grokImagePlanner.ts
@@ -18,6 +18,20 @@ import {
   type GrokResponsesResponse,
 } from "./grokImageCore.js";
 import { grokFetchWithRetry } from "./grokUpstreamRetry.js";
+import { resolveGrokCredential, type GrokCredential } from "./grokRuntime.js";
+
+/**
+ * Planner and search share the credential the adapter already resolved. Direct callers
+ * (lib/grokImageAdapter re-exports) may omit it, and the OAuth `grok` lane is the right
+ * default there: an explicit credential is what makes a call the `grok-api` lane.
+ */
+async function plannerCredential(
+  ctx: RouteRuntimeContext,
+  options: { credential?: GrokCredential | undefined; signal?: AbortSignal | undefined },
+): Promise<GrokCredential> {
+  if (options.credential) return options.credential;
+  return await resolveGrokCredential(ctx, "grok", { ...(options.signal ? { signal: options.signal } : {}) });
+}
 
 export function buildGrokPlannerPayload(
   prompt: string,
@@ -204,12 +218,12 @@ export function buildGrokSearchPayload(prompt: string, plannerModel = DEFAULT_GR
 export async function searchGrokVisualContext(
   prompt: string,
   ctx: RouteRuntimeContext,
-  options: { signal?: AbortSignal; requestId?: string; directApiKey?: string; plannerModel?: string } = {},
+  options: { signal?: AbortSignal; requestId?: string; credential?: GrokCredential; plannerModel?: string } = {},
 ): Promise<GrokSearchResult> {
   const planner = getPlannerConfig(ctx);
   const plannerModel = options.plannerModel || planner.model;
   const payload = buildGrokSearchPayload(prompt, plannerModel);
-  const { url, headers } = getGrokEndpoint(ctx, "/v1/responses", options.directApiKey);
+  const { url, headers } = getGrokEndpoint("/v1/responses", await plannerCredential(ctx, options));
   // The search brief has its own, smaller budget: it runs BEFORE the planner call inside
   // the same user request, so charging it the full planner budget lets one slow stage eat
   // the other's time. See devlog/_plan/260817_grok_video_planner_timeout/010.
@@ -280,7 +294,7 @@ export async function planGrokImage(
     requestId?: string | undefined;
     referenceCount?: number | undefined;
     references?: GrokReferenceImage[] | undefined;
-    directApiKey?: string | undefined;
+    credential?: GrokCredential | undefined;
     plannerModel?: string | undefined;
     backgroundConstraint?: string | undefined;
     webSearchEnabled?: boolean | undefined;
@@ -294,8 +308,9 @@ export async function planGrokImage(
   // record calls actually made (070 QA: search ran even with
   // webSearchEnabled:false, and webSearchCalls was hardcoded to 1).
   const searchEnabled = options.webSearchEnabled !== false;
+  const credential = await plannerCredential(ctx, options);
   const search = searchEnabled
-    ? await searchGrokVisualContext(prompt, ctx, { ...(options.signal ? { signal: options.signal } : {}), ...(options.requestId ? { requestId: options.requestId } : {}), ...(options.directApiKey ? { directApiKey: options.directApiKey } : {}), plannerModel })
+    ? await searchGrokVisualContext(prompt, ctx, { ...(options.signal ? { signal: options.signal } : {}), ...(options.requestId ? { requestId: options.requestId } : {}), credential, plannerModel })
     : { summary: "", skipped: true } as Awaited<ReturnType<typeof searchGrokVisualContext>>;
   const payload = buildGrokPlannerPayload(
     prompt,
@@ -307,7 +322,7 @@ export async function planGrokImage(
     options.references || options.referenceCount || 0,
     options.backgroundConstraint || "",
   );
-  const { url, headers } = getGrokEndpoint(ctx, "/v1/chat/completions", options.directApiKey);
+  const { url, headers } = getGrokEndpoint("/v1/chat/completions", credential);
   const { combinedSignal, timer } = withTimeoutSignal(options.signal, planner.timeoutMs);
 
   logEvent("grok", "planner:start", { requestId: options.requestId, plannerModel, imageModel, size: options.size });

--- a/lib/grokRuntime.ts
+++ b/lib/grokRuntime.ts
@@ -1,27 +1,93 @@
+/**
+ * Grok transport runtime: where a Grok request goes and which credential it carries.
+ *
+ * Both Grok lanes call https://api.x.ai directly. They differ only in where the bearer
+ * comes from: `grok` uses the xAI OAuth session in ~/.progrok/auth.json (lib/xaiAuth.ts),
+ * `grok-api` uses the configured XAI_API_KEY. The bundled progrok proxy that used to sit
+ * in front of the `grok` lane is no longer on the request path.
+ *
+ * MUST stay a leaf: imports only lib/xaiAuth.js and types. No config, routes, or adapters.
+ */
 import type { RouteRuntimeContext } from "./runtimeContext.js";
+import { getGrokAccessToken, type XaiTokenRetryDeps } from "./xaiAuth.js";
 
-const DEFAULT_GROK_PROXY_HOST = "127.0.0.1";
-const DEFAULT_GROK_PROXY_PORT = 18645;
+export type GrokLane = "grok" | "grok-api";
 
-function normalizeBaseUrl(url: string): string {
-  return url.replace(/\/v1\/?$/, "").replace(/\/$/, "");
-}
-
-export function getGrokProxyBaseUrl(ctx: RouteRuntimeContext = {}): string {
-  const grokCfg = (ctx.config as any)?.grokProvider || {};
-  const explicitUrl = (ctx as { grokUrl?: string }).grokUrl;
-  if (explicitUrl) return normalizeBaseUrl(explicitUrl);
-
-  const host = grokCfg.proxyHost || DEFAULT_GROK_PROXY_HOST;
-  const port = (ctx as { grokActualPort?: number }).grokActualPort || grokCfg.proxyPort || DEFAULT_GROK_PROXY_PORT;
-  return `http://${host}:${port}`;
-}
-
-export function getGrokProxyUrl(ctx: RouteRuntimeContext = {}, path = "/v1"): string {
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  return `${getGrokProxyBaseUrl(ctx)}${normalizedPath}`;
-}
+export type GrokCredential =
+  | { kind: "api-key"; key: string }
+  | { kind: "oauth"; token: string };
 
 export function getGrokDirectBaseUrl(): string {
   return "https://api.x.ai";
+}
+
+export function grokAuthHeaders(credential: GrokCredential): Record<string, string> {
+  const bearer = credential.kind === "api-key" ? credential.key : credential.token;
+  return { "Content-Type": "application/json", Authorization: `Bearer ${bearer}` };
+}
+
+export function getGrokEndpoint(
+  path = "/v1/images/generations",
+  credential: GrokCredential,
+): { url: string; headers: Record<string, string> } {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return { url: `${getGrokDirectBaseUrl()}${normalizedPath}`, headers: grokAuthHeaders(credential) };
+}
+
+export interface ResolveGrokCredentialOptions {
+  forceRefresh?: boolean;
+  /** The OAuth token that just got a 401; skips the refresh when the file already moved on. */
+  rejectedAccessToken?: string;
+  signal?: AbortSignal;
+  deps?: XaiTokenRetryDeps;
+}
+
+function grokCredentialError(code: string, status: number, message: string): Error & { code: string; status: number } {
+  return Object.assign(new Error(message), { code, status });
+}
+
+/**
+ * The single place a Grok lane turns into a bearer. For `grok` this may refresh the OAuth
+ * session, so it is async; GrokAuthError (GROK_AUTH_REQUIRED / GROK_AUTH_REFRESH_FAILED)
+ * propagates unchanged. For `grok-api` a missing key is GROK_API_KEY_MISSING, the same code
+ * the execution admission check emits.
+ */
+export async function resolveGrokCredential(
+  ctx: RouteRuntimeContext,
+  lane: GrokLane,
+  opts: ResolveGrokCredentialOptions = {},
+): Promise<GrokCredential> {
+  if (lane === "grok-api") {
+    const key = typeof ctx.xaiApiKey === "string" ? ctx.xaiApiKey.trim() : "";
+    if (!key) throw grokCredentialError("GROK_API_KEY_MISSING", 401, "Grok API key is required for grok-api");
+    return { kind: "api-key", key };
+  }
+  const token = await getGrokAccessToken({
+    ...(opts.forceRefresh !== undefined ? { forceRefresh: opts.forceRefresh } : {}),
+    ...(opts.rejectedAccessToken !== undefined ? { rejectedAccessToken: opts.rejectedAccessToken } : {}),
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    ...(opts.deps !== undefined ? { deps: opts.deps } : {}),
+    ...(ctx.grokAuthHomeDir !== undefined ? { homeDir: ctx.grokAuthHomeDir } : {}),
+  });
+  return { kind: "oauth", token };
+}
+
+/**
+ * Runs `doFetch` with a fresh credential and, on a 401 from an OAuth bearer, refreshes
+ * exactly once and replays. Nesting is fixed: this wrapper sits OUTSIDE grokFetchWithRetry
+ * (the 5xx/reset retrier), which cannot rebuild headers itself. grokUpstreamRetry stays a
+ * leaf and never sees credentials. A 401 arrives before any generation is billed, so the
+ * single replay is safe even for the non-idempotent image and video-start calls.
+ */
+export async function fetchWithGrokAuth<R extends { status: number }>(
+  ctx: RouteRuntimeContext,
+  lane: GrokLane,
+  doFetch: (credential: GrokCredential) => Promise<R>,
+  opts: Pick<ResolveGrokCredentialOptions, "signal" | "deps"> = {},
+): Promise<R> {
+  const first = await resolveGrokCredential(ctx, lane, opts);
+  const res = await doFetch(first);
+  if (res.status !== 401 || first.kind !== "oauth") return res;
+  const second = await resolveGrokCredential(ctx, lane, { ...opts, forceRefresh: true, rejectedAccessToken: first.token });
+  return doFetch(second);
 }

--- a/lib/grokVideoAdapter.ts
+++ b/lib/grokVideoAdapter.ts
@@ -18,6 +18,7 @@ import {
 } from "./imageModels.js";
 import { formatVideoContinuityForPlanner, type VideoContinuityLineage } from "./videoContinuity.js";
 import { DEFAULT_GROK_PLANNER_MODEL } from "../config.js";
+import { resolveGrokCredential, type GrokCredential } from "./grokRuntime.js";
 import {
   videoConfig,
   videoEndpoint,
@@ -111,6 +112,17 @@ export interface GrokVideoGenerateResult {
 }
 
 const canonicalVideoModel = canonicalGrokVideoModel;
+
+/**
+ * Every video call carries an explicit credential. Callers that resolved one (the HTTP
+ * routes, the extend operation) pass it down so a whole request uses a single bearer;
+ * callers that did not — the agent surface — get the OAuth lane, which is exactly what
+ * the removed proxy used to supply for them.
+ */
+async function videoCredential(ctx: RouteRuntimeContext, options: GrokVideoOptions): Promise<GrokCredential> {
+  if (options.credential) return options.credential;
+  return resolveGrokCredential(ctx, "grok", options.signal ? { signal: options.signal } : {});
+}
 
 function sourceImageUrl(image: string, mime?: string | null): string {
   if (image.startsWith("data:") || image.startsWith("http")) return image;
@@ -218,6 +230,7 @@ export function parseGrokVideoPlanPrompt(response: any): string {
 
 export async function planGrokVideo(prompt: string, ctx: RouteRuntimeContext, options: GrokVideoOptions = {}): Promise<GrokVideoPlan> {
   const cfg = videoConfig(ctx);
+  const credential = await videoCredential(ctx, options);
   const mode: VideoMode = options.mode || (options.sourceImage ? "image-to-video" : "text-to-video");
   const duration = options.duration ?? 5;
   const resolution = options.resolution || "480p";
@@ -244,7 +257,7 @@ export async function planGrokVideo(prompt: string, ctx: RouteRuntimeContext, op
     // own deadline would turn a slow search — the exact case 020 exists to degrade — into
     // GENERATION_CANCELED. The stage bound is applied inside that function via
     // getPlannerConfig().searchTimeoutMs.
-    const search = await searchGrokVisualContext(prompt, ctx, { signal: phaseSignal, ...(options.requestId ? { requestId: options.requestId } : {}), ...(options.directApiKey ? { directApiKey: options.directApiKey } : {}), plannerModel });
+    const search = await searchGrokVisualContext(prompt, ctx, { signal: phaseSignal, ...(options.requestId ? { requestId: options.requestId } : {}), credential, plannerModel });
     searchSummary = search.summary;
   } catch (e: any) { // justified: adapter rejections are untyped; the shape is narrowed here
     // A user cancellation is a real cancellation and must never be swallowed. Neither is
@@ -279,7 +292,7 @@ export async function planGrokVideo(prompt: string, ctx: RouteRuntimeContext, op
     continuityLineage: options.continuityLineage,
     backgroundConstraint: options.backgroundConstraint,
   });
-  const { url, headers } = videoEndpoint(ctx, "/v1/chat/completions", options.directApiKey);
+  const { url, headers } = videoEndpoint(ctx, "/v1/chat/completions", credential);
   const { combinedSignal, timer } = withTimeoutSignal(phaseSignal, cfg.plannerTimeoutMs);
   logEvent("grok", "video:planner:start", { requestId: options.requestId, mode, duration, resolution });
   try {
@@ -395,7 +408,7 @@ export function buildVideoGenerationPayload(plan: GrokVideoPlan, opts: { model: 
 
 export async function startVideoRequest(ctx: RouteRuntimeContext, payload: Record<string, unknown>, options: GrokVideoOptions): Promise<string> {
   const cfg = videoConfig(ctx);
-  const { url, headers } = videoEndpoint(ctx, "/v1/videos/generations", options.directApiKey);
+  const { url, headers } = videoEndpoint(ctx, "/v1/videos/generations", await videoCredential(ctx, options));
   const { combinedSignal, timer } = withTimeoutSignal(options.signal, cfg.startTimeoutMs);
   try {
     // NOT wrapped in grokFetchWithRetry on purpose: a reset or 5xx here may follow a job
@@ -424,6 +437,9 @@ export async function startVideoRequest(ctx: RouteRuntimeContext, payload: Recor
 
 export async function generateVideoViaGrok(prompt: string, ctx: RouteRuntimeContext, options: GrokVideoOptions = {}): Promise<GrokVideoGenerateResult> {
   const cfg = videoConfig(ctx);
+  // Resolve once for the whole request: plan, start, and poll must all carry the same
+  // bearer, and re-resolving per stage would refresh the OAuth session repeatedly.
+  const effective: GrokVideoOptions = { ...options, credential: await videoCredential(ctx, options) };
   const model = canonicalVideoModel(options.model || cfg.model);
   const srcUrl = options.sourceImage ? sourceImageUrl(options.sourceImage, options.sourceMime) : undefined;
   const refUrls = (options.referenceImages ?? []).map((img) => sourceImageUrl(img, undefined));
@@ -438,7 +454,7 @@ export async function generateVideoViaGrok(prompt: string, ctx: RouteRuntimeCont
         aspectRatio: options.aspectRatio || "auto",
         webSearchCalls: options.webSearchCalls ?? 1,
       }
-    : await planGrokVideo(prompt, ctx, options);
+    : await planGrokVideo(prompt, ctx, effective);
   let xaiVideoRequestId: string;
   let effectiveModel = model;
 
@@ -458,7 +474,7 @@ export async function generateVideoViaGrok(prompt: string, ctx: RouteRuntimeCont
   }
 
   try {
-    xaiVideoRequestId = await startVideoRequest(ctx, effectivePayload, options);
+    xaiVideoRequestId = await startVideoRequest(ctx, effectivePayload, effective);
   } catch (e: any) {
     // Fallback: if 1.5-preview still fails, retry with base model.
     // Not when voices are attached: the base model rejects reference_audios outright, so
@@ -467,7 +483,7 @@ export async function generateVideoViaGrok(prompt: string, ctx: RouteRuntimeCont
     if (model !== GROK_VIDEO_MODEL_BASE && e?.status === 400 && voices.length === 0) {
       effectiveModel = GROK_VIDEO_MODEL_BASE;
       const fallbackPayload = buildVideoGenerationPayload(plan, { model: effectiveModel, sourceImageUrl: srcUrl, referenceImageUrls: refUrls });
-      xaiVideoRequestId = await startVideoRequest(ctx, fallbackPayload, options);
+      xaiVideoRequestId = await startVideoRequest(ctx, fallbackPayload, effective);
       logEvent("grok", "video:fallback", { requestId: options.requestId, from: model, to: effectiveModel });
     } else {
       throw e;
@@ -476,7 +492,7 @@ export async function generateVideoViaGrok(prompt: string, ctx: RouteRuntimeCont
   const modelFallback = effectiveModel === model ? null : { from: model, to: effectiveModel };
   options.onEvent?.({ phase: "submitted", xaiVideoRequestId, requestedModel: model, effectiveModel, modelFallback });
   logEvent("grok", "video:submitted", { requestId: options.requestId, xaiVideoRequestId, mode: plan.mode });
-  const poll = await pollVideoUntilDone(ctx, xaiVideoRequestId, options);
+  const poll = await pollVideoUntilDone(ctx, xaiVideoRequestId, effective);
   if (!poll.videoUrl) throw grokError("Grok video done without a video url", 502, "GROK_VIDEO_EMPTY_RESPONSE");
   if (poll.respectModeration === false) throw grokError("Grok video blocked by moderation", 502, "GROK_VIDEO_MODERATION_BLOCKED");
   const { buffer, contentType } = await downloadVideo(ctx, poll.videoUrl, options.signal);

--- a/lib/grokVideoPoll.ts
+++ b/lib/grokVideoPoll.ts
@@ -11,6 +11,7 @@
 import type { RouteRuntimeContext } from "./runtimeContext.js";
 import { grokError } from "./grokImageCore.js";
 import { grokFetchWithRetry } from "./grokUpstreamRetry.js";
+import type { GrokCredential } from "./grokRuntime.js";
 import {
   FAILED_CODE_MAP,
   STALE_PROGRESS_MS,
@@ -39,10 +40,10 @@ export async function pollVideoOnce(
   ctx: RouteRuntimeContext,
   requestId: string,
   signal?: AbortSignal,
-  directApiKey?: string,
+  credential?: GrokCredential,
 ): Promise<GrokVideoPollResult> {
   const cfg = videoConfig(ctx);
-  const { url, headers } = videoEndpoint(ctx, `/v1/videos/${requestId}`, directApiKey);
+  const { url, headers } = videoEndpoint(ctx, `/v1/videos/${requestId}`, credential);
   const { combinedSignal, timer } = withTimeoutSignal(signal, cfg.startTimeoutMs);
   try {
     const res = await grokFetchWithRetry(
@@ -88,7 +89,7 @@ export async function pollVideoUntilDone(
     if (Date.now() > deadline) throw grokError("Grok video poll budget exceeded", 504, "GROK_VIDEO_TIMEOUT");
     let poll: GrokVideoPollResult;
     try {
-      poll = await pollVideoOnce(ctx, requestId, options.signal, options.directApiKey);
+      poll = await pollVideoOnce(ctx, requestId, options.signal, options.credential);
       consecutiveErrors = 0;
     } catch (e: any) { // justified: grokError attaches code/status at runtime
       // The upstream job outlives a transient poll failure, so a blip must not discard a

--- a/lib/grokVideoShared.ts
+++ b/lib/grokVideoShared.ts
@@ -10,7 +10,7 @@
  * poll loop.
  */
 import type { RouteRuntimeContext } from "./runtimeContext.js";
-import { getGrokProxyUrl } from "./grokRuntime.js";
+import { getGrokEndpoint, type GrokCredential } from "./grokRuntime.js";
 import { grokError } from "./grokImageCore.js";
 import { GROK_FALLBACK_VIDEO_MODEL } from "./imageModels.js";
 import type { VideoAspectRatio, VideoMode, VideoResolution } from "./imageModels.js";
@@ -56,7 +56,7 @@ export interface GrokVideoOptions {
   webSearchCalls?: number | undefined;
   continuityLineage?: VideoContinuityLineage | null | undefined;
   plannerModel?: string | undefined;
-  directApiKey?: string | undefined;
+  credential?: GrokCredential | undefined;
   onEvent?: (ev: GrokVideoEvent) => void | undefined;
   storyboardActive?: boolean | undefined;
   backgroundConstraint?: string | undefined;
@@ -110,18 +110,10 @@ export function videoConfig(ctx: RouteRuntimeContext): VideoConfig {
   };
 }
 
-export function videoEndpoint(ctx: RouteRuntimeContext, path: string, directApiKey?: string) {
-  if (directApiKey) {
-    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-    return {
-      url: `https://api.x.ai${normalizedPath}`,
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${directApiKey}` },
-    };
-  }
-  return {
-    url: getGrokProxyUrl(ctx, path),
-    headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" },
-  };
+/** Same endpoint builder as images; kept under the video name so the poll loop stays a leaf. */
+export function videoEndpoint(_ctx: RouteRuntimeContext, path: string, credential?: GrokCredential) {
+  if (!credential) throw grokError("Grok credential was not resolved before the request", 500, "GROK_CREDENTIAL_UNRESOLVED");
+  return getGrokEndpoint(path, credential);
 }
 
 export function withTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number) {

--- a/lib/promptBuilder/router.ts
+++ b/lib/promptBuilder/router.ts
@@ -1,4 +1,5 @@
-import { getGrokEndpoint } from "../grokImageCore.js";
+import { getGrokEndpoint, resolveGrokCredential, type GrokCredential } from "../grokRuntime.js";
+import { GrokAuthError } from "../xaiAuth.js";
 import { waitForOAuthReady } from "../oauthProxy/runtime.js";
 import type { RuntimeContext } from "../runtimeContext.js";
 import {
@@ -44,6 +45,28 @@ function unavailableBackendError(backend: ResolvedPromptBuilderBackend): Error {
       : "PROMPT_BUILDER_GROK_UNAVAILABLE",
     503,
   );
+}
+
+/**
+ * Both Grok lanes now go through the same resolver, so a missing credential surfaces as the
+ * lane's own "unavailable" error instead of a raw auth failure. A refresh that fails against
+ * xAI is a real upstream fault and propagates unchanged.
+ */
+async function grokCredential(
+  ctx: RuntimeContext,
+  backend: "grok" | "grok-api",
+): Promise<GrokCredential> {
+  try {
+    return await resolveGrokCredential(ctx, backend);
+  } catch (error) {
+    if (error instanceof GrokAuthError && error.code === "GROK_AUTH_REQUIRED") {
+      throw unavailableBackendError("grok");
+    }
+    if ((error as { code?: string } | null)?.code === "GROK_API_KEY_MISSING") {
+      throw unavailableBackendError("grok-api");
+    }
+    throw error;
+  }
 }
 
 export function selectPromptBuilderBackend(
@@ -104,11 +127,7 @@ export async function resolvePromptBuilderTransport(
         useOAuthFetch: false,
       };
     }
-    const directApiKey = backend === "grok-api" ? ctx.xaiApiKey : undefined;
-    if (backend === "grok-api" && !directApiKey) {
-      throw unavailableBackendError("grok-api");
-    }
-    const target = getGrokEndpoint(ctx, "/v1/chat/completions", directApiKey);
+    const target = getGrokEndpoint("/v1/chat/completions", await grokCredential(ctx, backend));
     return { ...target, useOAuthFetch: false };
   } catch (error) {
     throw error;

--- a/lib/providers/adapters/grokExecution.ts
+++ b/lib/providers/adapters/grokExecution.ts
@@ -1,5 +1,6 @@
 import type { RuntimeContext } from "../../runtimeContext.js";
 import { planGrokImage } from "../../grokImagePlanner.js";
+import { resolveGrokCredential, type GrokCredential } from "../../grokRuntime.js";
 import { resolveGrokQualityModel } from "../../imageModels.js";
 import { toGrokReferences } from "../../nodeHelpers.js";
 import { generateViaGrok, editViaGrok } from "./grokOperations.js";
@@ -24,7 +25,7 @@ async function prepareGrokClassic(
     ? [{ b64: "", url: request.providerUrl, declaredMime: "image/png", detectedMime: "image/png" }, ...request.references]
     : request.references;
   // Keep classic's once-per-batch key and shared plan capture before any image attempt.
-  const grokDirectApiKey = activeProvider === "grok-api" ? ctx.xaiApiKey : undefined;
+  const credential = await resolveGrokCredential(ctx, activeProvider, { signal: request.signal });
   const sharedGrokPlan = await planGrokImage(generationPrompt, ctx, {
     model: resolveGrokQualityModel(imageModel, quality),
     size: effectiveSize,
@@ -32,7 +33,7 @@ async function prepareGrokClassic(
     requestId,
     referenceCount: grokRefs.length,
     references: grokRefs,
-    directApiKey: grokDirectApiKey,
+    credential,
     backgroundConstraint: request.backgroundConstraint,
     webSearchEnabled,
   });
@@ -46,25 +47,25 @@ async function prepareGrokClassic(
       plannedPrompt: sharedGrokPlan?.prompt,
       webSearchCalls: sharedGrokPlan?.webSearchCalls,
       references: grokRefs,
-      directApiKey: grokDirectApiKey,
+      credential,
     });
     return { kind: "single", value };
   } };
 }
 
-function prepareGrokNode(
+async function prepareGrokNode(
   ctx: RuntimeContext, request: Extract<GrokRequest, { surface: "node" }>,
-): PreparedImageExecution<"node"> {
-  // The outer execution boundary checks current presence; retries retain this key.
-  const grokDirectApiKey = request.provider === "grok-api" ? ctx.xaiApiKey : undefined;
+): Promise<PreparedImageExecution<"node">> {
+  // The outer execution boundary checks current presence; retries retain this credential.
+  const credential = await resolveGrokCredential(ctx, request.provider, { signal: request.signal });
   return { execute: async () => {
-    return { kind: "single", value: await executeGrokNode(ctx, request, grokDirectApiKey) };
+    return { kind: "single", value: await executeGrokNode(ctx, request, credential) };
   } };
 }
 
 async function executeGrokNode(
   ctx: RuntimeContext, request: Extract<GrokRequest, { surface: "node" }>,
-  grokDirectApiKey: string | undefined,
+  credential: GrokCredential,
 ): Promise<SingleImageExecutionResult> {
   const { sourceImage: parentB64, prompt: generationPrompt, references, requestId, signal, options } = request;
   const { model, size, webSearchEnabled } = options;
@@ -72,7 +73,7 @@ async function executeGrokNode(
   return await generateViaGrok(generationPrompt, ctx, {
     model, size, requestId, signal,
     references: toGrokReferences(parentB64, refsForRequest),
-    directApiKey: grokDirectApiKey,
+    credential,
     webSearchEnabled,
   });
 }
@@ -81,10 +82,10 @@ async function executeGrokEdit(
   ctx: RuntimeContext, request: Extract<GrokRequest, { surface: "edit" }>,
 ): Promise<SingleImageExecutionResult> {
   const { provider, rawPrompt, sourceImage, signal, requestId, options } = request;
-  const directApiKey = provider === "grok-api" ? ctx.xaiApiKey : undefined;
+  const credential = await resolveGrokCredential(ctx, provider, { signal });
   return await editViaGrok(rawPrompt, sourceImage, ctx, {
     model: resolveGrokQualityModel(options.model, options.quality),
-    size: options.size, signal, requestId, directApiKey,
+    size: options.size, signal, requestId, credential,
   });
 }
 
@@ -93,12 +94,12 @@ async function executeGrokMultimode(
   progress: ExecutionProgress,
 ): Promise<SequenceImageExecutionResult> {
   const { provider, prompt, references, signal, requestId, options, maxImages } = request;
-  const directApiKey = provider === "grok-api" ? ctx.xaiApiKey : undefined;
+  const credential = await resolveGrokCredential(ctx, provider, { signal });
   const grokRefs = request.providerUrl
     ? [{ b64: "", url: request.providerUrl }, ...references] : references;
   return await generateMultimodeViaGrok(prompt, ctx, {
     model: resolveGrokQualityModel(options.model, options.quality), maxImages,
-    size: options.size, signal, requestId, references: grokRefs, directApiKey,
+    size: options.size, signal, requestId, references: grokRefs, credential,
     onFinalImage: progress.onFinalImage,
     webSearchEnabled: options.webSearchEnabled,
   });
@@ -112,7 +113,7 @@ export async function prepareGrokExecution(
 ): Promise<PreparedImageExecution<ExecutionSurface>> {
   switch (request.surface) {
     case "classic": return await prepareGrokClassic(ctx, request);
-    case "node": return prepareGrokNode(ctx, request);
+    case "node": return await prepareGrokNode(ctx, request);
     case "edit": return { execute: async () => {
       return { kind: "single", value: await executeGrokEdit(ctx, request) };
     } };

--- a/lib/providers/adapters/grokMultimodeOperations.ts
+++ b/lib/providers/adapters/grokMultimodeOperations.ts
@@ -8,7 +8,7 @@ import {
   type GrokReferenceImage,
 } from "../../grokImageCore.js";
 import { planGrokImage } from "../../grokImagePlanner.js";
-import { getGrokProxyBaseUrl } from "../../grokRuntime.js";
+import { resolveGrokCredential, type GrokCredential } from "../../grokRuntime.js";
 import { logEvent } from "../../logger.js";
 import type { RouteRuntimeContext } from "../../runtimeContext.js";
 
@@ -45,7 +45,7 @@ export async function generateMultimodeViaGrok(
     signal?: AbortSignal | undefined;
     requestId?: string | undefined;
     references?: GrokReferenceImage[] | undefined;
-    directApiKey?: string | undefined;
+    credential?: GrokCredential | undefined;
     webSearchEnabled?: boolean | undefined;
     onFinalImage?: ((image: { b64: string; revisedPrompt?: string | undefined; mime?: string | undefined }, index: number) => void | Promise<void>) | undefined;
   } = {},
@@ -60,6 +60,10 @@ export async function generateMultimodeViaGrok(
     Math.max(1, Math.trunc(Number(options.maxImages) || 4)),
   );
   const references = options.references || [];
+  // One credential for the whole batch: a per-item resolve would refresh the OAuth
+  // session mid-run and give items inconsistent bearers.
+  const credential = options.credential
+    ?? await resolveGrokCredential(ctx, "grok", { ...(options.signal ? { signal: options.signal } : {}) });
   const images: Array<{ b64: string; revisedPrompt?: string; mime?: string; providerUrl?: string }> = [];
   const originalIndexes: number[] = [];
   let totalCost = 0;
@@ -78,7 +82,7 @@ export async function generateMultimodeViaGrok(
       signal: options.signal,
       requestId: options.requestId,
       references,
-      directApiKey: options.directApiKey,
+      credential,
       webSearchEnabled: options.webSearchEnabled,
     });
     totalWebSearchCalls += plan.webSearchCalls;
@@ -95,13 +99,11 @@ export async function generateMultimodeViaGrok(
         refs: references.length,
         promptChars: plan.prompt.length,
       });
-      const result = await postGrokImages(ctx, payload, options.signal, endpoint, options.directApiKey);
+      const result = await postGrokImages(ctx, payload, options.signal, endpoint, credential);
       const imgUrl = result.data?.[0]?.url;
       if (imgUrl) {
-        const dl = await downloadGrokImageUrl(imgUrl, options.signal, undefined, {
-          trustedProxyOrigin: options.directApiKey
-            ? undefined : new URL(getGrokProxyBaseUrl(ctx)).origin,
-        });
+        // Direct lane: the artifact URL is a public https origin, so no proxy hop is trusted.
+        const dl = await downloadGrokImageUrl(imgUrl, options.signal);
         const img = { b64: dl.b64, mime: dl.mime, revisedPrompt: plan.prompt, providerUrl: imgUrl };
         images.push(img);
         originalIndexes.push(i);

--- a/lib/providers/adapters/grokOperations.ts
+++ b/lib/providers/adapters/grokOperations.ts
@@ -2,7 +2,7 @@ import { logEvent } from "../../logger.js";
 import { detectImageMimeFromB64 } from "../../refs.js";
 import type { RouteRuntimeContext } from "../../runtimeContext.js";
 import { mapSizeToGrokImageParams } from "../../grokSizeMapper.js";
-import { getGrokProxyBaseUrl } from "../../grokRuntime.js";
+import { resolveGrokCredential, type GrokCredential } from "../../grokRuntime.js";
 import { planGrokImage } from "../../grokImagePlanner.js";
 import {
   grokError,
@@ -13,6 +13,20 @@ import {
   type GrokGenerateResult,
   type GrokReferenceImage,
 } from "../../grokImageCore.js";
+
+/**
+ * Execution resolves the credential once per request and threads it down. Legacy direct
+ * callers (lib/grokImageAdapter, lib/agentImageVideoGen) omit it, and for them the OAuth
+ * `grok` lane is the correct default: the api-key lane is only ever reached by passing a
+ * credential explicitly.
+ */
+async function requireCredential(
+  ctx: RouteRuntimeContext,
+  options: { credential?: GrokCredential | undefined; signal?: AbortSignal | undefined },
+): Promise<GrokCredential> {
+  if (options.credential) return options.credential;
+  return await resolveGrokCredential(ctx, "grok", { ...(options.signal ? { signal: options.signal } : {}) });
+}
 
 export async function generateViaGrok(
   prompt: string,
@@ -25,16 +39,17 @@ export async function generateViaGrok(
     plannedPrompt?: string | undefined;
     webSearchCalls?: number | undefined;
     references?: GrokReferenceImage[] | undefined;
-    directApiKey?: string | undefined;
+    credential?: GrokCredential | undefined;
     plannerModel?: string | undefined;
     webSearchEnabled?: boolean | undefined;
   } = {},
 ): Promise<GrokGenerateResult> {
   const model = options.model || (ctx.config as any).grokProvider?.defaultImageModel || "grok-imagine-image-quality";
   const references = options.references || [];
+  const credential = await requireCredential(ctx, options);
   const plan = options.plannedPrompt
     ? { prompt: options.plannedPrompt, model, webSearchCalls: options.webSearchCalls ?? 1 }
-    : await planGrokImage(prompt, ctx, { ...options, referenceCount: references.length, directApiKey: options.directApiKey, webSearchEnabled: options.webSearchEnabled });
+    : await planGrokImage(prompt, ctx, { ...options, referenceCount: references.length, credential, webSearchEnabled: options.webSearchEnabled });
   const hasReferences = references.length > 0;
   const payload = hasReferences
     ? imageEditPayload(model, plan.prompt, references, options.size)
@@ -49,16 +64,14 @@ export async function generateViaGrok(
     size: options.size,
     refs: references.length,
   });
-  const result = await postGrokImages(ctx, payload, options.signal, endpoint, options.directApiKey);
+  const result = await postGrokImages(ctx, payload, options.signal, endpoint, credential);
 
   const imageUrl = result.data?.[0]?.url;
   if (!imageUrl) {
     throw grokError("Grok returned no image URL", 502, "GROK_EMPTY_RESPONSE");
   }
-  const downloaded = await downloadGrokImageUrl(imageUrl, options.signal, undefined, {
-    trustedProxyOrigin: options.directApiKey
-      ? undefined : new URL(getGrokProxyBaseUrl(ctx)).origin,
-  });
+  // Direct lane: the artifact URL is a public https origin, so no proxy hop is trusted.
+  const downloaded = await downloadGrokImageUrl(imageUrl, options.signal);
 
   const usage = result.usage ? { grok_cost_usd_ticks: result.usage.cost_in_usd_ticks ?? 0 } : null;
   logEvent("grok", "generate:done", {
@@ -76,22 +89,19 @@ export async function editViaGrok(
   prompt: string,
   imageB64: string,
   ctx: RouteRuntimeContext,
-  options: { model?: string | undefined; size?: string | undefined; signal?: AbortSignal | undefined; requestId?: string | undefined; directApiKey?: string | undefined } = {},
+  options: { model?: string | undefined; size?: string | undefined; signal?: AbortSignal | undefined; requestId?: string | undefined; credential?: GrokCredential | undefined } = {},
 ): Promise<GrokGenerateResult> {
   const model = options.model || (ctx.config as any).grokProvider?.defaultImageModel || "grok-imagine-image-quality";
   const detectedInputMime = detectImageMimeFromB64(imageB64) || "image/png";
   const imageUrl = imageB64.startsWith("data:") ? imageB64 : `data:${detectedInputMime};base64,${imageB64}`;
   const payload: Record<string, unknown> = { model, prompt, n: 1, response_format: "url", image: { type: "image_url", url: imageUrl }, ...mapSizeToGrokImageParams(options.size) };
   logEvent("grok", "edit:start", { requestId: options.requestId, model, promptChars: prompt.length });
-  const result = await postGrokImages(ctx, payload, options.signal, "/v1/images/edits", options.directApiKey);
+  const result = await postGrokImages(ctx, payload, options.signal, "/v1/images/edits", await requireCredential(ctx, options));
   const editResultUrl = result.data?.[0]?.url;
   if (!editResultUrl) {
     throw grokError("Grok edit returned no image URL", 502, "GROK_EMPTY_RESPONSE");
   }
-  const downloaded = await downloadGrokImageUrl(editResultUrl, options.signal, undefined, {
-    trustedProxyOrigin: options.directApiKey
-      ? undefined : new URL(getGrokProxyBaseUrl(ctx)).origin,
-  });
+  const downloaded = await downloadGrokImageUrl(editResultUrl, options.signal);
   const usage = result.usage ? { grok_cost_usd_ticks: result.usage.cost_in_usd_ticks ?? 0 } : null;
   logEvent("grok", "edit:done", { requestId: options.requestId, model, b64Len: downloaded.b64.length });
   return { b64: downloaded.b64, providerUrl: editResultUrl, usage, webSearchCalls: 0, mime: downloaded.mime, revisedPrompt: result.data[0]?.revised_prompt || prompt };

--- a/lib/providers/execution/admission.ts
+++ b/lib/providers/execution/admission.ts
@@ -1,19 +1,34 @@
 import type { RuntimeContext } from "../../runtimeContext.js";
 import { getProviderSurfaceSupport } from "../derive.js";
+import { loadGrokCredentials } from "../../xaiAuth.js";
 import type { CoreProviderId } from "../registry.js";
 import type { ProviderSurface } from "../types.js";
 import type { ExecutionSurface } from "./types.js";
 
 type AdmissionFailure = {
   status: 400 | 401;
-  code: "GROK_API_KEY_MISSING" | "NAI_REF_UNSUPPORTED";
+  code: "GROK_API_KEY_MISSING" | "GROK_AUTH_REQUIRED" | "NAI_REF_UNSUPPORTED";
   message: string;
 };
 
+/**
+ * Both Grok lanes are admitted the same way: the api-key lane needs XAI_API_KEY, and the
+ * OAuth lane needs a stored xAI session. loadGrokCredentials is synchronous and never
+ * throws, so this stays a cheap presence check — expiry and refresh belong to
+ * resolveGrokCredential at the actual request.
+ */
 function directKeyFailure(ctx: RuntimeContext, provider: CoreProviderId): AdmissionFailure | null {
-  if (provider !== "grok-api" || (typeof ctx.xaiApiKey === "string" && ctx.xaiApiKey.trim())) return null;
-  return { status: 401, code: "GROK_API_KEY_MISSING",
-    message: "Grok API key is required for grok-api image generation" };
+  if (provider === "grok-api") {
+    if (typeof ctx.xaiApiKey === "string" && ctx.xaiApiKey.trim()) return null;
+    return { status: 401, code: "GROK_API_KEY_MISSING",
+      message: "Grok API key is required for grok-api image generation" };
+  }
+  if (provider === "grok") {
+    if (loadGrokCredentials(ctx.grokAuthHomeDir)) return null;
+    return { status: 401, code: "GROK_AUTH_REQUIRED",
+      message: "Grok login required. Run: ima2 grok login" };
+  }
+  return null;
 }
 
 export function checkImageExecutionAdmission(ctx: RuntimeContext, input: {

--- a/lib/runtimeContext.ts
+++ b/lib/runtimeContext.ts
@@ -26,6 +26,11 @@ export interface RuntimeContext {
   grokProxy?: GrokProxyHandle | undefined;
   /** True only while a supervised child is actually listening. */
   grokProxyLive?: boolean | undefined;
+  /**
+   * Directory whose `.progrok/auth.json` holds the xAI OAuth session. Tests inject an
+   * isolated HOME here; production leaves it undefined and lib/xaiAuth.ts uses os.homedir().
+   */
+  grokAuthHomeDir?: string | undefined;
   hasApiKey: boolean;
   oauthActualPort: number | undefined;
   oauthPort: number;

--- a/lib/videoExtendI2vOperation.ts
+++ b/lib/videoExtendI2vOperation.ts
@@ -1,5 +1,6 @@
 import type { RouteRuntimeContext, RuntimeContext } from "./runtimeContext.js";
 import type { GrokVideoEvent, GrokVideoGenerateResult, GrokVideoOptions } from "./grokVideoAdapter.js";
+import { resolveGrokCredential } from "./grokRuntime.js";
 import type { persistVideoArtifact } from "./videoArtifactPersistence.js";
 import { appendVideoContinuityEntry, lineageFromVideoMetadata } from "./videoContinuity.js";
 import { deriveChildVideoLineage } from "./videoLineage.js";
@@ -61,11 +62,14 @@ export async function runLastFrameI2v(task: LastFrameI2vTask): Promise<void> {
       });
     };
     const compiledPrompt = motion.fragment ? `${prompt}\n\nCamera motion: ${motion.fragment}.` : prompt;
+    // Resolved before the generate call so a missing key or an expired session fails here,
+    // as a normal job error, instead of midway through the provider request.
+    const credential = await resolveGrokCredential(ctx, provider, { signal: cancelController.signal });
     const result = await generateVideo(compiledPrompt, ctx, {
       model, mode: "image-to-video", duration, resolution, aspectRatio,
       sourceImage, sourceMime: "image/png", signal: cancelController.signal,
       requestId, continuityLineage: parentContinuity,
-      directApiKey: provider === "grok-api" ? ctx.xaiApiKey ?? undefined : undefined,
+      credential,
       onEvent,
     });
     if (cancelController.signal.aborted) throw makeGenerationCanceledError();

--- a/routes/grok.ts
+++ b/routes/grok.ts
@@ -1,33 +1,40 @@
 import type { Express } from "express";
 import type { RouteRuntimeContext } from "../lib/runtimeContext.js";
-import { getGrokProxyBaseUrl, getGrokProxyUrl } from "../lib/grokRuntime.js";
+import { fetchWithGrokAuth, getGrokEndpoint } from "../lib/grokRuntime.js";
+
+/**
+ * The status probe now asks api.x.ai directly with the stored OAuth session, so it
+ * reports on the credential the generation lane actually uses. There is no local child
+ * to promote or restart, which is why the old probe token and proxy state are gone; the
+ * four status literals stay unchanged because the UI switches on them.
+ */
+function statusFromError(error: unknown): { status: string; reason?: string } {
+  const code = (error as { code?: unknown } | null)?.code;
+  if (code === "GROK_AUTH_REQUIRED") return { status: "offline", reason: "login_required" };
+  if (code === "GROK_AUTH_REFRESH_FAILED") {
+    const message = error instanceof Error ? error.message : "token refresh failed";
+    return { status: "error", reason: message };
+  }
+  return { status: "offline" };
+}
 
 export function registerGrokRoutes(app: Express, ctx: RouteRuntimeContext) {
   app.get("/api/grok/status", async (_req, res) => {
-    const grokCfg = (ctx.config as any).grokProvider || {};
-    const timeoutMs = grokCfg.statusTimeoutMs || 3000;
-    // Captured BEFORE the await: a response that outlives its child must not be
-    // able to promote a dead proxy back to ready.
-    const token = ctx.grokProxy?.probeToken();
+    const timeoutMs = ctx.config?.grokProvider?.statusTimeoutMs ?? 3000;
     try {
-      const r = await fetch(getGrokProxyUrl(ctx, "/v1/models"), {
-        signal: AbortSignal.timeout(timeoutMs),
+      const r = await fetchWithGrokAuth(ctx, "grok", (credential) => {
+        const { url, headers } = getGrokEndpoint("/v1/models", credential);
+        return fetch(url, { headers, signal: AbortSignal.timeout(timeoutMs) });
       });
       if (r.ok) {
-        const data: any = await r.json();
-        const models: string[] = data?.data?.map((m: any) => m.id).filter(Boolean) || [];
-        const hasImageModel = models.some((m: string) => m.startsWith("grok-imagine"));
-        // A live 200 is stronger evidence than stdout parsing, which only
-        // recognizes 127.0.0.1/localhost and so can strand a custom host.
-        if (token) ctx.grokProxy?.markProbedReady(token, getGrokProxyBaseUrl(ctx));
+        const data = await r.json() as { data?: { id?: unknown }[] };
+        const models: string[] = (data?.data ?? []).map((m) => m?.id).filter((id): id is string => typeof id === "string" && id.length > 0);
+        const hasImageModel = models.some((m) => m.startsWith("grok-imagine"));
         return res.json({ status: hasImageModel ? "ready" : "no_image_model", models });
       }
-      return res.json({ status: "error", reason: `HTTP ${r.status}`, state: ctx.grokProxy?.state });
-    } catch {
-      // Deliberately does NOT call ensure(): the UI polls every 10s while not
-      // ready, so self-healing here would spawn a child per poll forever.
-      // Recovery is driven by the login event only.
-      return res.json({ status: "offline", state: ctx.grokProxy?.state });
+      return res.json({ status: "error", reason: `HTTP ${r.status}` });
+    } catch (error) {
+      return res.json(statusFromError(error));
     }
   });
 }

--- a/routes/video.ts
+++ b/routes/video.ts
@@ -13,6 +13,7 @@ import { logEvent, logError } from "../lib/logger.js";
 import { parseBackgroundPreset, backgroundPromptSuffix, backgroundPlannerConstraint } from "../lib/backgroundPresets.js";
 import { invalidateHistoryIndex } from "../lib/historyIndex.js";
 import { generateVideoViaGrok, type GrokVideoEvent } from "../lib/grokVideoAdapter.js";
+import { resolveGrokCredential, type GrokLane } from "../lib/grokRuntime.js";
 import { generateVideoViaComfy, type ComfyQueueInfo } from "../lib/comfyImageAdapter.js";
 import { getVideoSeriesChain } from "../lib/videoSeriesChain.js";
 import {
@@ -540,7 +541,11 @@ export function registerVideoRoutes(app: Express, ctxRaw: RouteRuntimeContext) {
         + (backgroundPreset ? ` ${backgroundPromptSuffix(backgroundPreset, "video")}` : "");
 
       const plannerModel = typeof req.body?.plannerModel === "string" ? req.body.plannerModel.trim() : undefined;
-      const directApiKey = provider === "grok-api" ? ctx.xaiApiKey : undefined;
+      // `provider` comes off the untyped body; the comfy branch already returned, so the
+      // only values left are the two Grok lanes. Narrow explicitly so the lane the
+      // credential is resolved for is a real GrokLane rather than an `any` passthrough.
+      const lane: GrokLane = provider === "grok-api" ? "grok-api" : "grok";
+      const credential = await resolveGrokCredential(ctx, lane, { signal: cancelController.signal });
 
       const result = await generateVideoViaGrok(effectivePrompt, ctx, {
         model: modelCheck.model,
@@ -555,7 +560,7 @@ export function registerVideoRoutes(app: Express, ctxRaw: RouteRuntimeContext) {
         requestId,
         continuityLineage: parentLineage,
         plannerModel: plannerModel || undefined,
-        directApiKey,
+        credential,
         onEvent,
         storyboardActive,
         backgroundConstraint: backgroundPreset ? backgroundPlannerConstraint(backgroundPreset) : undefined,

--- a/routes/videoExtended.ts
+++ b/routes/videoExtended.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import type { RouteRuntimeContext, RuntimeContext } from "../lib/runtimeContext.js";
 import { requireRuntimeContext } from "../lib/runtimeContext.js";
-import { getGrokProxyUrl } from "../lib/grokRuntime.js";
+import { fetchWithGrokAuth, getGrokEndpoint, resolveGrokCredential, type GrokLane } from "../lib/grokRuntime.js";
 import { logEvent, logError } from "../lib/logger.js";
 import { downloadVideo, generateVideoViaGrok, pollVideoUntilDone, type GrokVideoGenerateResult, type GrokVideoOptions } from "../lib/grokVideoAdapter.js";
 import { invalidateHistoryIndex } from "../lib/historyIndex.js";
@@ -66,8 +66,13 @@ function motionSelection(value: unknown, parent: ParentMetadata | null): { ids: 
   return { ids, fragment: ids.map((id) => getMotionFragment(id, "grok")).filter(Boolean).join(", ") };
 }
 
-function videoProxyUrl(ctx: RuntimeContext, path: string) {
-  return { url: getGrokProxyUrl(ctx, path), headers: { "Content-Type": "application/json", Authorization: "Bearer dummy" } };
+/**
+ * These handlers take the lane from the request body, which is untyped. Anything that is
+ * not the explicit API-key lane runs on the OAuth session, the same default the rest of
+ * the video surface uses.
+ */
+function videoLane(body: unknown): GrokLane {
+  return (body as { provider?: unknown } | null)?.provider === "grok-api" ? "grok-api" : "grok";
 }
 
 function routeError(message: string, status = 400): Error & { status: number } {
@@ -185,6 +190,23 @@ function extractOutputText(data: Record<string, unknown>): string {
   return texts.join("\n").trim();
 }
 
+/** The global fetch response; `Response` in this module is Express's. */
+type FetchResponse = Awaited<ReturnType<typeof fetch>>;
+
+/**
+ * The frame analysis call is a single request with nothing downstream, so it resolves its
+ * credential through fetchWithGrokAuth: an expired OAuth bearer is refreshed once and the
+ * request replayed, which costs nothing because a 401 arrives before any work is billed.
+ */
+async function requestFrameAnalysis(
+  ctx: RouteRuntimeContext, lane: GrokLane, body: Record<string, unknown>, signal: AbortSignal,
+): Promise<FetchResponse> {
+  return fetchWithGrokAuth(ctx, lane, (credential) => {
+    const { url, headers } = getGrokEndpoint("/v1/responses", credential);
+    return fetch(url, { method: "POST", headers, body: JSON.stringify(body), signal });
+  }, { signal });
+}
+
 export function registerVideoExtendedRoutes(app: Express, ctxRaw: RouteRuntimeContext, dependencies: VideoExtendedDependencies = {}) {
   const ctx = requireRuntimeContext(ctxRaw);
   const extractFrame = dependencies.extractFrame ?? ((dir, filename, position, options) => extractGeneratedVideoFrameB64(dir, filename, position, options));
@@ -203,7 +225,9 @@ export function registerVideoExtendedRoutes(app: Express, ctxRaw: RouteRuntimeCo
       const validModel = validateEditModel(model);
       const signal = requestSignal(req, res, envDeadline("IMA2_VIDEO_EDIT_TIMEOUT_MS", 10 * 60_000));
 
-      const { url, headers } = videoProxyUrl(ctx, "/v1/videos/edits");
+      // Resolved once and carried into the poll loop so the whole edit runs on one bearer.
+      const credential = await resolveGrokCredential(ctx, videoLane(req.body), { signal });
+      const { url, headers } = getGrokEndpoint("/v1/videos/edits", credential);
       const video = await resolveVideoInput(ctx, videoUrl);
       const apiRes = await fetch(url, { method: "POST", headers, body: JSON.stringify({ model: validModel, prompt, video }), signal });
       if (!apiRes.ok) { const t = await apiRes.text(); return res.status(apiRes.status).json({ error: t }); }
@@ -211,7 +235,7 @@ export function registerVideoExtendedRoutes(app: Express, ctxRaw: RouteRuntimeCo
       if (!request_id) return res.status(502).json({ error: "No request_id in response" });
       logEvent("video", "edit:start", { requestId: request_id, model: validModel });
 
-      const result = await pollVideoUntilDone(ctx, request_id, { signal });
+      const result = await pollVideoUntilDone(ctx, request_id, { signal, credential });
       if (result.respectModeration === false) return res.status(502).json({ error: "Grok video blocked by moderation" });
       if (!result.videoUrl) return res.status(502).json({ error: "No video URL in response" });
       const saved = await saveVideoResult(ctx, { requestId: request_id, prompt, model: validModel, operation: "edit", source: videoUrl, duration: result.duration ?? null, videoUrl: result.videoUrl, usage: result.usage, signal });
@@ -338,13 +362,14 @@ export function registerVideoExtendedRoutes(app: Express, ctxRaw: RouteRuntimeCo
         return res.status(400).json({ error: `duration must be an integer between ${MIN_VIDEO_DURATION} and ${MAX_VIDEO_DURATION}` });
       }
       const signal = requestSignal(req, res, envDeadline("IMA2_VIDEO_EXTEND_TIMEOUT_MS", 10 * 60_000));
-      const { url, headers } = videoProxyUrl(ctx, "/v1/videos/extensions");
+      const credential = await resolveGrokCredential(ctx, videoLane(req.body), { signal });
+      const { url, headers } = getGrokEndpoint("/v1/videos/extensions", credential);
       const video = await resolveVideoInput(ctx, videoUrl);
       const apiRes = await fetch(url, { method: "POST", headers, body: JSON.stringify({ model: validModel, prompt, duration: dur, video }), signal });
       if (!apiRes.ok) { const t = await apiRes.text(); return res.status(apiRes.status).json({ error: t }); }
       const { request_id } = (await apiRes.json()) as { request_id: string };
       if (!request_id) return res.status(502).json({ error: "No request_id in response" });
-      const result = await pollVideoUntilDone(ctx, request_id, { signal });
+      const result = await pollVideoUntilDone(ctx, request_id, { signal, credential });
       if (result.respectModeration === false) return res.status(502).json({ error: "Grok video blocked by moderation" });
       if (!result.videoUrl) return res.status(502).json({ error: "No video URL in response" });
       const saved = await saveVideoResult(ctx, { requestId: request_id, prompt, model: validModel, operation: "extend", source: videoUrl, duration: result.duration ?? null, videoUrl: result.videoUrl, usage: result.usage, signal });
@@ -432,23 +457,17 @@ export function registerVideoExtendedRoutes(app: Express, ctxRaw: RouteRuntimeCo
         const first = (await readFile(firstFrame)).toString("base64");
         const last = (await readFile(lastFrame)).toString("base64");
         const plannerModel = ctx.config.grokProvider.plannerModel || DEFAULT_GROK_PLANNER_MODEL;
-        const { url, headers } = videoProxyUrl(ctx, "/v1/responses");
-        const apiRes = await fetch(url, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            model: plannerModel,
-            input: [{
-              role: "user",
-              content: [
-                { type: "input_image", image_url: `data:image/png;base64,${first}`, detail: "high" },
-                { type: "input_image", image_url: `data:image/png;base64,${last}`, detail: "high" },
-                { type: "input_text", text: "Analyze these first and last frames from a video for recreation. Infer likely motion between them. Include shot type, camera movement, lighting, color palette, subjects, motion direction/speed, mood, and audio/sound prompt suggestions. Be specific and cinematic." },
-              ],
-            }],
-          }),
-          signal,
-        });
+        const apiRes = await requestFrameAnalysis(ctx, videoLane(req.body), {
+          model: plannerModel,
+          input: [{
+            role: "user",
+            content: [
+              { type: "input_image", image_url: `data:image/png;base64,${first}`, detail: "high" },
+              { type: "input_image", image_url: `data:image/png;base64,${last}`, detail: "high" },
+              { type: "input_text", text: "Analyze these first and last frames from a video for recreation. Infer likely motion between them. Include shot type, camera movement, lighting, color palette, subjects, motion direction/speed, mood, and audio/sound prompt suggestions. Be specific and cinematic." },
+            ],
+          }],
+        }, signal);
         if (!apiRes.ok) { const t = await apiRes.text(); return res.status(apiRes.status).json({ error: t }); }
         const data = (await apiRes.json()) as Record<string, unknown>;
         const text = extractOutputText(data);

--- a/structure/01-file-function-map.md
+++ b/structure/01-file-function-map.md
@@ -87,8 +87,8 @@ routes/
 | `routes/generate.ts` | 13 | Classic generation API route wiring |
 | `routes/edit.ts` | 416 | Edit API, mask validation, cancellation, OAuth/API edit response save, alpha verification (alphaVerified/alphaReason), provider/web-search/reasoning-effort plumbing |
 | `routes/multimode.ts` | 10 | `POST /api/generate/multimode` route wiring |
-| `routes/video.ts` | 679 | `POST /api/video/generate` SSE: Grok video T2V/I2V/Ref2V, active prompt guard, continuation lineage, sidecar persistence |
-| `routes/videoExtended.ts` | 468 | Video edit, extension, frame extraction, and configured-planner first/last-frame analysis (Grok 4.5 default) |
+| `routes/video.ts` | 684 | `POST /api/video/generate` SSE: Grok video T2V/I2V/Ref2V, active prompt guard, continuation lineage, sidecar persistence |
+| `routes/videoExtended.ts` | 487 | Video edit, extension, frame extraction, and configured-planner first/last-frame analysis (Grok 4.5 default) |
 | `routes/nodes.ts` | 28 | Node generation and node fetch route wiring |
 | `routes/sessions.ts` | 318 | SQLite-backed session list/load/save/rename/delete, style-sheet get/put/enable/extract, graph save |
 | `routes/history.ts` | 234 | History list, cursor pagination, favorites-only filtering, grouped gallery, soft delete (OS trash), restore, gallery favorite toggle, permanent delete |
@@ -179,9 +179,9 @@ scope/revision/identity reconciliation shared by polling and reload actions.
 | `lib/videoContinuity.ts` | 193 | Video active-prompt guard, generated video sidecar lineage read/normalize/append, max-4 continuity retention, planner context formatting |
 | `lib/videoFrameExtract.ts` | 100 | Generated-dir-safe MP4 validation and ffmpeg frame extraction for video frame/analyze/continue workflows |
 | `lib/videoGenerationRequest.ts` | 166 | Shared generate-request contract: mode inference, mutually-exclusive source guard, and duration/resolution/aspect defaults for UI, CLI, agent, and route |
-| `lib/grokVideoAdapter.ts` | 503 | Grok video planner and xAI video generation adapter, including continuity-aware prompt planning and model fallback metadata |
-| `lib/grokVideoShared.ts` | 161 | Shared Grok video types, config, endpoint, and timeout helpers keeping the adapter/poll dependency one-way |
-| `lib/grokVideoPoll.ts` | 117 | Grok video status polling with transient-failure tolerance so a network blip cannot discard a long render |
+| `lib/grokVideoAdapter.ts` | 519 | Grok video planner and xAI video generation adapter, including continuity-aware prompt planning and model fallback metadata |
+| `lib/grokVideoShared.ts` | 153 | Shared Grok video types, config, endpoint, and timeout helpers keeping the adapter/poll dependency one-way |
+| `lib/grokVideoPoll.ts` | 118 | Grok video status polling with transient-failure tolerance so a network blip cannot discard a long render |
 | `lib/localImportStore.ts` | 115 | Validates raw PNG/JPEG/WebP body, writes timestamped `imported-*` to generated/, embeds XMP metadata, returns GenerateItem-shaped row |
 | `lib/storageMigration.ts` | 311 | Legacy generated-folder scan and migration support |
 | `lib/runtimePorts.ts` | 106 | Port probing, fallback binding, and OAuth ready URL parsing |
@@ -217,7 +217,7 @@ scope/revision/identity reconciliation shared by polling and reload actions.
 | `lib/providers/adapters/openaiOperations.ts` | 235 | Actual OpenAI generate/edit/multimode operation bodies and reference normalization |
 | `lib/providers/adapters/openaiExecution.ts` | 142 | Typed four-surface OpenAI owner, classic retry and native callback/result mapping |
 | `lib/providerOptions.ts` | 161 | Per-provider option assembly; rejects catalog-only Comfy video workflows on the classic image path |
-| `lib/runtimeContext.ts` | 234 | Per-request runtime context plumbing for routes and lib helpers |
+| `lib/runtimeContext.ts` | 239 | Per-request runtime context plumbing for routes and lib helpers |
 | `lib/errInfo.ts` | 44 | Error info shape and helpers shared across routes/lib |
 | `lib/oauthNormalize.ts` | 31 | Upstream OAuth response field normalization |
 | `lib/openDirectory.ts` | 48 | Cross-platform open of the generated directory (used by `/api/storage/open-generated-dir`) |
@@ -237,7 +237,7 @@ scope/revision/identity reconciliation shared by polling and reload actions.
 | `lib/providers/derive.ts` | 97 | Registry-bound provider IDs, catalogs, reference limits and surface support |
 | `lib/providers/surfaceSupport.ts` | 31 | Pure application-surface projection, independent of readiness; static versus runtime catalogs |
 | `lib/providers/execution/types.ts` | 102 | Typed surface-discriminated requests, native single/sequence results and callbacks |
-| `lib/providers/execution/admission.ts` | 38 | Missing direct-Grok key and unsupported NAI multimode-ref checks; no provider probing |
+| `lib/providers/execution/admission.ts` | 53 | Missing direct-Grok key and unsupported NAI multimode-ref checks; no provider probing |
 | `lib/providers/execution/index.ts` | 36 | Public prepare/execute facade with current direct-key presence checks |
 | `lib/providers/execution/legacy.ts` | 31 | Four-surface Atlas/MiniMax/NAI/Comfy dispatcher; OpenAI/Grok/Google excluded |
 | `lib/providers/execution/legacyClassic.ts` | 15 | Remaining-provider classic dispatch with preserved prepare-time capture |
@@ -280,23 +280,23 @@ scope/revision/identity reconciliation shared by polling and reload actions.
 | `lib/providers/adapters/geminiOperations.ts` | 265 | Actual public/Vertex image payload, auth selection and unchanged native response/error handling |
 | `lib/generationCancel.ts` | 29 | Shared generation cancellation helpers |
 | `lib/generationInputValidation.ts` | 46 | Shared generation request input validation |
-| `lib/grokImageCore.ts` | 194 | Shared Grok image request and response handling |
-| `lib/grokImagePlanner.ts` | 353 | Actual Grok search/planner operations, payload builders and plan parser |
-| `lib/providers/adapters/grokExecution.ts` | 124 | Four-surface Grok/proxy and direct execution, captured keys and search forwarding |
-| `lib/providers/adapters/grokOperations.ts` | 99 | Actual generate/edit operations with scoped artifact-origin policy |
-| `lib/providers/adapters/grokMultimodeOperations.ts` | 124 | Ordered per-image planning and sparse original-index result identity |
+| `lib/grokImageCore.ts` | 186 | Shared Grok image request and response handling |
+| `lib/grokImagePlanner.ts` | 368 | Actual Grok search/planner operations, payload builders and plan parser |
+| `lib/providers/adapters/grokExecution.ts` | 125 | Four-surface Grok/proxy and direct execution, captured keys and search forwarding |
+| `lib/providers/adapters/grokOperations.ts` | 109 | Actual generate/edit operations with scoped artifact-origin policy |
+| `lib/providers/adapters/grokMultimodeOperations.ts` | 126 | Ordered per-image planning and sparse original-index result identity |
 | `lib/grokImageDownloadPolicy.ts` | 128 | Conservative address policy, exact-origin exception and abort-aware pinned DNS resolution |
 | `lib/grokImageDownload.ts` | 153 | Grok redirect trust, overall deadline, bounded streamed image body and cleanup |
 | `lib/pinnedHttpGet.ts` | 173 | Shared validated-address GET lifecycle, public redirect handling and bounded text bodies |
 | `lib/grokMultimodeAdapter.ts` | 6 | Compatibility re-exports of actual Grok multimode operation/type |
 | `lib/grokProxyLauncher.ts` | 326 | Grok proxy process startup and readiness helpers |
-| `lib/grokRuntime.ts` | 28 | Grok runtime configuration helpers |
+| `lib/grokRuntime.ts` | 94 | Grok runtime configuration helpers |
 | `lib/xaiAuth.ts` | 464 | xAI OAuth credential store (~/.progrok/auth.json), single-flight refresh, terminal-failure negative cache |
 | `lib/grokUpstreamRetry.ts` | 165 | Pre-response retry guard for idempotent Grok fetches: socket resets, transient 5xx, Retry-After backoff |
 | `lib/grokSizeMapper.ts` | 86 | Grok model image-size mapping and validation |
 | `lib/grokVideoCanvas.ts` | 41 | Grok video canvas/source preparation helpers |
 | `lib/grokVideoDownload.ts` | 167 | Bounded incremental video download, validation and reader cleanup; callers own persistence |
-| `lib/videoExtendI2vOperation.ts` | 101 | Actual whole last-frame background operation Promise, preserving phase/persistence/terminal order |
+| `lib/videoExtendI2vOperation.ts` | 105 | Actual whole last-frame background operation Promise, preserving phase/persistence/terminal order |
 | `lib/grokVideoPlannerPrompt.ts` | 225 | Grok video planner prompt construction |
 | `lib/historyIndex.ts` | 57 | Generated-history index construction and lookup |
 | `lib/imageThumb.ts` | 50 | Image thumbnail generation helpers |
@@ -346,12 +346,12 @@ Backed by `routes/agent.ts`; no CLI wrapper. Session/turn/queue persistence and 
 | `lib/agentQueueWorker.ts` | 226 | Background queue worker |
 | `lib/agentCommandParser.ts` | 77 | Slash-command parsing |
 | `lib/agentToolManifest.ts` | 31 | Tool metadata for `/api/agent/tools` |
-| `lib/agentPlannerModel.ts` | 202 | Planner model selection |
+| `lib/agentPlannerModel.ts` | 203 | Planner model selection |
 | `lib/agentGenerationPlanner.ts` | 356 | Generation plan assembly |
 | `lib/agentImageVideoGen.ts` | 477 | Image/video generation caller for agent turns |
 | `lib/agentQuestionResponder.ts` | 275 | `/question` responder |
 | `lib/promptBuilder/constants.ts` | 32 | Prompt Builder backend/model catalogs, defaults, and deterministic Auto order |
-| `lib/promptBuilder/router.ts` | 117 | Ready-lane selection, explicit-backend fail-closed errors, and transport targets |
+| `lib/promptBuilder/router.ts` | 136 | Ready-lane selection, explicit-backend fail-closed errors, and transport targets |
 | `lib/promptBuilder/client.ts` | 201 | Request normalization, backend/model resolution, safe fallback logging, one-shot upstream request, and resolved-backend response metadata |
 
 ## UI File Map

--- a/tests/_executionBoundaryProbe.ts
+++ b/tests/_executionBoundaryProbe.ts
@@ -5,6 +5,7 @@ import type { RuntimeContext } from "../lib/runtimeContext.ts";
 import type { CoreProviderId } from "../lib/providers/registry.ts";
 import type { ExecutionProgress, ExecutionSurface, ImageExecutionRequest, SingleImageExecutionResult, SequenceImageExecutionResult } from "../lib/providers/execution/types.ts";
 import { isolateExecution } from "./_executionRouteIsolation.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 interface Call { name: string; args: unknown[] }
 const transports = {
@@ -20,6 +21,8 @@ const transports = {
 
 export async function openBoundaryProbe() {
   const isolation = await isolateExecution();
+  // The OAuth `grok` lane resolves a real bearer during prepare; keep it off the real HOME.
+  const grokAuth = seedGrokAuth();
   const calls: Call[] = [];
   const mocks: Array<{ restore(): void }> = [];
   let failure: unknown;
@@ -71,9 +74,11 @@ export async function openBoundaryProbe() {
     const { createTestRuntimeContext } = await import("../lib/runtimeContext.ts");
     const { prepareImageExecution } = await import("../lib/providers/execution/index.ts");
     const { prepareLegacyImageExecution } = await import("../lib/providers/execution/legacy.ts");
-    const ctx = createTestRuntimeContext({ rootDir: isolation.rootDir, config, xaiApiKey: "initial-invented-key" });
+    const ctx = createTestRuntimeContext({ rootDir: isolation.rootDir, config, xaiApiKey: "initial-invented-key",
+      grokAuthHomeDir: grokAuth.homeDir });
     const source = (await sharp({ create: { width: 8, height: 8, channels: 3, background: "#654321" } }).png().toBuffer()).toString("base64");
-    return { calls, single, sequence, callbackImage, partial, queue, ctx, source, prepareImageExecution, prepareLegacyImageExecution,
+    return { calls, single, sequence, callbackImage, partial, queue, ctx, source, grokBearer: grokAuth.bearer,
+      prepareImageExecution, prepareLegacyImageExecution,
       failWith(error?: unknown) { failure = error; },
       planSearchCalls(value: number) { plannedSearchCalls = value; },
       callbackPromise() { return callbackWork; },
@@ -81,12 +86,12 @@ export async function openBoundaryProbe() {
       async close() {
         (await import("../lib/db.ts")).closeDb();
         for (const entry of mocks.reverse()) entry.restore();
-        await isolation.close();
+        try { await isolation.close(); } finally { grokAuth.cleanup(); }
       },
     };
   } catch (error) {
     for (const entry of mocks.reverse()) entry.restore();
-    await isolation.close();
+    try { await isolation.close(); } finally { grokAuth.cleanup(); }
     throw error;
   }
 }

--- a/tests/_executionRouteHarness.ts
+++ b/tests/_executionRouteHarness.ts
@@ -9,6 +9,7 @@ import type { RuntimeContext } from "../lib/runtimeContext.ts";
 import { assertOwned, isolateExecution } from "./_executionRouteIsolation.ts";
 import { bounded, drain, installTrackedWrites, PromiseTracker, SettlementTimeout } from "./_executionTrackedWrites.ts";
 import { listenOwnedLoopback, type ImageTransportFixture } from "./_grokImageTransportFixture.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 export type Surface = "classic" | "node" | "multimode" | "edit";
 export interface UpstreamCall {
@@ -120,11 +121,14 @@ export async function openRouteHarness(): Promise<RouteHarness> {
   const isolation = await isolateExecution();
   let restoreWrites: (() => void) | undefined;
   let modules: Awaited<ReturnType<typeof loadRuntime>>;
+  // The `grok` lane reads ~/.progrok/auth.json. Seed an isolated HOME once per harness so
+  // no case can reach the developer's real xAI session or its live token endpoint.
+  const grokAuth = seedGrokAuth();
   try {
     restoreWrites = await installTrackedWrites();
     modules = await loadRuntime(isolation.rootDir);
   } catch (error) {
-    try { restoreWrites?.(); } finally { await isolation.close(); }
+    try { restoreWrites?.(); } finally { grokAuth.cleanup(); await isolation.close(); }
     throw error;
   }
   let sequence = 0;
@@ -161,7 +165,7 @@ export async function openRouteHarness(): Promise<RouteHarness> {
     isolation.imageTransport.activate({ hosts: imageHosts, respond: upstream });
     const ctx = modules.runtime.createTestRuntimeContext({
       apiKey: "sk-execution-fixture", oauthReadyState: "ready", oauthUrl: "http://oauth-fixture.invalid",
-      grokUrl: "http://grok-fixture.invalid/v1", ...options.context,
+      grokAuthHomeDir: grokAuth.homeDir, ...options.context,
       rootDir: isolation.rootDir,
       config: { ...modules.config, storage: { ...modules.config.storage, generatedDir } },
     });
@@ -241,7 +245,7 @@ export async function openRouteHarness(): Promise<RouteHarness> {
       failure = error;
     }
     try { modules.db.closeDb(); restoreWrites?.(); }
-    finally { await isolation.close(); closed = true; }
+    finally { grokAuth.cleanup(); await isolation.close(); closed = true; }
     if (failure) throw failure;
   } };
 }

--- a/tests/_grokAuthFixture.ts
+++ b/tests/_grokAuthFixture.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Seeds an isolated HOME with a ~/.progrok/auth.json so the grok lane resolves an OAuth
+ * bearer without touching the developer's real session. Pass the returned homeDir as
+ * `grokAuthHomeDir` on the runtime context.
+ */
+export const GROK_FIXTURE_TOKEN = "grok-oauth-fixture-token";
+/** The Authorization header every seeded OAuth (`grok`) lane fixture must send. */
+export const GROK_FIXTURE_BEARER = `Bearer ${GROK_FIXTURE_TOKEN}`;
+
+export function seedGrokAuth(options: {
+  accessToken?: string; refreshToken?: string; expiresAt?: number; homeDir?: string;
+} = {}): { homeDir: string; accessToken: string; bearer: string; cleanup: () => void } {
+  const homeDir = options.homeDir ?? mkdtempSync(join(tmpdir(), "ima2-grok-auth-"));
+  const accessToken = options.accessToken ?? GROK_FIXTURE_TOKEN;
+  const dir = join(homeDir, ".progrok");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(join(dir, "auth.json"), JSON.stringify({
+    accessToken,
+    refreshToken: options.refreshToken ?? "grok-oauth-fixture-refresh",
+    expiresAt: options.expiresAt ?? Date.now() + 60 * 60 * 1000,
+    tokenEndpoint: "https://auth.x.ai/oauth2/token",
+  }, null, 2), { mode: 0o600 });
+  return {
+    homeDir, accessToken, bearer: `Bearer ${accessToken}`,
+    cleanup: () => rmSync(homeDir, { recursive: true, force: true }),
+  };
+}

--- a/tests/_videoExecutionFixture.ts
+++ b/tests/_videoExecutionFixture.ts
@@ -15,8 +15,11 @@ import { PromiseTracker, SettlementTimeout } from "./_executionTrackedWrites.ts"
 import { listenOwnedLoopback } from "./_grokImageTransportFixture.ts";
 import { captureFfmpegCapability, installVideoFfmpeg, type FfmpegAttempt } from "./_videoFfmpegFixture.ts";
 import { forbidArtifactArrayBuffer, type makeVideoStreamFixture } from "./_videoStreamFixture.ts";
+import { GROK_FIXTURE_BEARER, seedGrokAuth } from "./_grokAuthFixture.ts";
 
 export type { UpstreamCall };
+/** Both Grok lanes now call xAI directly; only the credential differs. */
+export const GROK_DIRECT_ORIGIN = "https://api.x.ai";
 type Codec = Awaited<ReturnType<typeof installVideoFfmpeg>>;
 type Isolation = Awaited<ReturnType<typeof isolateExecution>>;
 type Stream = ReturnType<typeof makeVideoStreamFixture>;
@@ -83,18 +86,25 @@ function origin(server: Server): string {
   return `http://127.0.0.1:${address.port}`;
 }
 
+/** The owned mock upstream stands in for api.x.ai, so map the direct origin onto it. */
+function ownedTarget(call: UpstreamCall, server: Server): string {
+  const url = new URL(call.url);
+  return url.origin === origin(server) ? call.url : `${origin(server)}${url.pathname}${url.search}`;
+}
+
 function validateProxy(call: UpstreamCall, server: Server, artifactPath: string): boolean {
   const url = new URL(call.url);
-  assert.equal(url.origin, origin(server));
   assert.equal(url.username + url.password + url.search + url.hash, "");
   assert.equal(call.headers.has("cookie"), false);
-  if (url.pathname === artifactPath) {
+  if (url.origin === origin(server) && url.pathname === artifactPath) {
     assert.equal(call.method, "GET"); assert.equal(call.body, "");
     assert.equal(call.headers.has("authorization"), false);
     return true;
   }
+  // Every authenticated video call leaves for the direct xAI origin.
+  assert.equal(url.origin, GROK_DIRECT_ORIGIN);
   const posts = ["/v1/responses", "/v1/chat/completions", "/v1/videos/generations", "/v1/videos/edits", "/v1/videos/extensions"];
-  assert.equal(call.headers.get("authorization"), "Bearer dummy");
+  assert.equal(call.headers.get("authorization"), GROK_FIXTURE_BEARER);
   if (call.method === "POST" && posts.includes(url.pathname)) {
     assert.match(call.headers.get("content-type") ?? "", /^application\/json(?:;|$)/);
     const body: unknown = JSON.parse(call.body);
@@ -124,6 +134,7 @@ class VideoFixture {
   app: Server | undefined;
   responder: Responder | undefined;
   finishing: Promise<void> | undefined;
+  grokAuth: ReturnType<typeof seedGrokAuth> | undefined;
   closed = false;
   frozen = false;
   active = false;
@@ -238,7 +249,7 @@ class VideoFixture {
       try {
         const artifact = validateProxy(call, server, artifactPath);
         validate(call);
-        const response = await this.isolation.fetchOwned(server, call.url, {
+        const response = await this.isolation.fetchOwned(server, ownedTarget(call, server), {
           method: call.method, headers: call.headers, signal: call.signal, redirect: "error",
           ...(call.body ? { body: call.body } : {}),
         });
@@ -324,7 +335,7 @@ class VideoFixture {
       for (const restore of this.restores.reverse()) restore();
       this.ffmpeg?.restore();
       await this.isolation.close();
-    } finally { this.closed = true; this.restoreEnv(); }
+    } finally { this.closed = true; this.grokAuth?.cleanup(); this.restoreEnv(); }
     if (failure) throw failure;
   }
 }
@@ -410,6 +421,8 @@ export async function openVideoFixture(options: { codec?: boolean } = {}) {
   try {
     const isolation = await isolateExecution();
     fixture = new VideoFixture(isolation, restoreEnv);
+    // Isolated xAI OAuth session: the `grok` lane must never read the real ~/.progrok.
+    fixture.grokAuth = seedGrokAuth();
     if (options.codec) fixture.ffmpeg = await installVideoFfmpeg(isolation.rootDir, capability, fixture.violations);
     fixture.modules = await loadRuntime(isolation.rootDir);
     await installObservers(fixture);
@@ -419,6 +432,7 @@ export async function openVideoFixture(options: { codec?: boolean } = {}) {
     if (fixture) {
       for (const restore of fixture.restores.reverse()) restore();
       fixture.ffmpeg?.restore(); fixture.modules?.db.closeDb();
+      fixture.grokAuth?.cleanup();
       await fixture.isolation.close();
     }
     restoreEnv(); throw error;
@@ -428,6 +442,9 @@ export async function openVideoFixture(options: { codec?: boolean } = {}) {
 function publicFixture(fixture: VideoFixture) {
   return {
     root: fixture.isolation.rootDir, config: fixture.modules.config as RuntimeContext["config"],
+    /** Pass as `grokAuthHomeDir` on any context that reaches the OAuth `grok` lane. */
+    grokAuthHomeDir: fixture.grokAuth!.homeDir,
+    grokBearer: fixture.grokAuth!.bearer,
     calls: fixture.calls, violations: fixture.violations, ffmpeg: fixture.ffmpeg,
     beginCase: fixture.beginCase.bind(fixture),
     trackApp: fixture.trackApp.bind(fixture), listen: fixture.listen.bind(fixture),

--- a/tests/agent-mode-llm-planner-contract.test.ts
+++ b/tests/agent-mode-llm-planner-contract.test.ts
@@ -3,10 +3,13 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 const TEST_DIR = mkdtempSync(join(tmpdir(), "ima2-agent-planner-"));
 process.env.IMA2_CONFIG_DIR = TEST_DIR;
 process.env.IMA2_DB_PATH = join(TEST_DIR, "sessions.db");
+// The grok planner lane resolves an OAuth bearer from ~/.progrok/auth.json.
+const grokAuth = seedGrokAuth();
 
 const { AGENT_ALLOWED_TOOLS } = await import("../lib/agentTypes.ts");
 const { AGENT_TOOL_MANIFEST, formatToolManifestForPrompt } = await import("../lib/agentToolManifest.ts");
@@ -24,6 +27,7 @@ afterEach(() => {
 
 after(() => {
   db.closeDb();
+  grokAuth.cleanup();
   rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -32,6 +36,7 @@ function plannerCtx() {
     config: { agentPlanner: { enabled: true, timeoutMs: 5_000 }, log: { level: "silent" } },
     oauthUrl: "http://127.0.0.1:9",
     packageVersion: "test",
+    grokAuthHomeDir: grokAuth.homeDir,
   };
 }
 

--- a/tests/agent-mode-runtime-contract.test.ts
+++ b/tests/agent-mode-runtime-contract.test.ts
@@ -9,10 +9,14 @@ import { bounded, drain, installTrackedWrites } from "./_executionTrackedWrites.
 import { listenOwnedLoopback } from "./_grokImageTransportFixture.ts";
 import { executionTestProcess } from "./_executionTestProcess.ts";
 import { forbidArtifactArrayBuffer } from "./_videoStreamFixture.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 import type { RuntimeContext } from "../lib/runtimeContext.ts";
 
 if (executionTestProcess(import.meta.url)) {
 const isolation = await isolateExecution();
+// The agent's Grok lanes read ~/.progrok/auth.json; keep them on an isolated HOME.
+const grokAuth = seedGrokAuth();
+const XAI_ORIGIN = "https://api.x.ai";
 const { imageTransport } = isolation;
 const TEST_DIR = isolation.rootDir;
 const deniedFetch = globalThis.fetch;
@@ -28,7 +32,7 @@ after(async () => {
   try { stopQueueWorker?.(); await drain(); }
   finally {
     try { closeDb?.(); restoreWrites?.(); }
-    finally { await isolation.close(); }
+    finally { try { await isolation.close(); } finally { grokAuth.cleanup(); } }
   }
 });
 beforeEach(() => { globalThis.fetch = fetchOwnedApp; });
@@ -96,6 +100,7 @@ function videoArtifact(response: Response) {
 function agentVideoContext(generatedDir: string): RuntimeContext {
   return {
     rootDir: TEST_DIR, packageVersion: "test",
+    grokAuthHomeDir: grokAuth.homeDir,
     config: {
       ...config, storage: { ...config.storage, generatedDir },
       grokProvider: { ...config.grokProvider, proxyHost: "127.0.0.1", proxyPort: 18645,
@@ -132,8 +137,8 @@ function installAgentVideoResponder(artifact: Response) {
         assert.equal(request.headers.get("authorization"), null);
         counts.artifact++; return artifact;
       }
-      assert.equal(url.origin, "http://127.0.0.1:18645"); assert.equal(url.search, "");
-      assert.equal(request.headers.get("authorization"), "Bearer dummy");
+      assert.equal(url.origin, XAI_ORIGIN); assert.equal(url.search, "");
+      assert.equal(request.headers.get("authorization"), grokAuth.bearer);
       if (url.pathname === "/v1/videos/agent-failure") {
         assert.equal(request.method, "GET"); assert.equal(await request.text(), ""); counts.poll++;
         return Response.json({ status: "done", video: { url: "https://vidgen.example/agent-failure.mp4", duration: 5, respect_moderation: true } });
@@ -228,6 +233,7 @@ async function withApp(fn: (baseUrl: string, generatedDir: string) => Promise<vo
   app.use(express.json({ limit: "8mb" }));
   registerAgentRoutes(app, {
     apiKey: "sk-test",
+    grokAuthHomeDir: grokAuth.homeDir,
     config: {
       storage: { generatedDir },
       log: { level: "silent" },
@@ -505,6 +511,7 @@ describe("Agent Mode runtime contract", () => {
       {
         rootDir: process.cwd(),
         packageVersion: "test",
+        grokAuthHomeDir: grokAuth.homeDir,
         config: {
           ...config,
           storage: { ...config.storage, generatedDir },
@@ -594,6 +601,7 @@ describe("Agent Mode runtime contract", () => {
       {
         rootDir: process.cwd(),
         packageVersion: "test",
+        grokAuthHomeDir: grokAuth.homeDir,
         config: {
           ...config,
           storage: { ...config.storage, generatedDir },

--- a/tests/api-provider-parity.test.ts
+++ b/tests/api-provider-parity.test.ts
@@ -7,8 +7,11 @@ import { join } from "node:path";
 import { assertOwned, isolateExecution } from "./_executionRouteIsolation.ts";
 import { drain, installTrackedWrites } from "./_executionTrackedWrites.ts";
 import { listenOwnedLoopback } from "./_grokImageTransportFixture.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 const isolation = await isolateExecution();
+// grok-lane cases resolve an OAuth bearer from ~/.progrok/auth.json; isolate that HOME.
+const grokAuth = seedGrokAuth();
 const { imageTransport } = isolation;
 const deniedFetch = globalThis.fetch;
 const originalFetch = isolation.nativeFetch;
@@ -20,7 +23,7 @@ after(async () => {
   try { await drain(); }
   finally {
     try { closeDb?.(); restoreWrites?.(); }
-    finally { await isolation.close(); }
+    finally { try { await isolation.close(); } finally { grokAuth.cleanup(); } }
   }
 });
 afterEach(async () => {
@@ -88,6 +91,7 @@ async function withApp(fn, { apiKey = "sk-test" } = {}) {
   const ctx = {
     rootDir,
     apiKey,
+    grokAuthHomeDir: grokAuth.homeDir,
     config: {
       ...config,
       storage: { ...config.storage, generatedDir },

--- a/tests/backend-hardening-contract.test.js
+++ b/tests/backend-hardening-contract.test.js
@@ -21,7 +21,7 @@ test("extended video operations combine disconnect and deadline signals", () => 
   assert.match(video, /IMA2_VIDEO_EDIT_TIMEOUT_MS/);
   assert.match(video, /IMA2_VIDEO_EXTEND_TIMEOUT_MS/);
   assert.match(video, /IMA2_VIDEO_ANALYZE_TIMEOUT_MS/);
-  assert.match(video, /pollVideoUntilDone\(ctx, request_id, \{ signal \}\)/);
+  assert.match(video, /pollVideoUntilDone\(ctx, request_id, \{ signal, credential \}\)/);
   assert.match(video, /\/v1\/responses[\s\S]+?signal,/);
 });
 

--- a/tests/error-envelope-contract.test.ts
+++ b/tests/error-envelope-contract.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { join } from "node:path";
 import { executionTestProcess } from "./_executionTestProcess.ts";
-import type { UpstreamCall } from "./_videoExecutionFixture.ts";
+import { GROK_DIRECT_ORIGIN, type UpstreamCall } from "./_videoExecutionFixture.ts";
 
 if (executionTestProcess(import.meta.url)) {
 const { openVideoFixture } = await import("./_videoExecutionFixture.ts");
@@ -78,7 +78,7 @@ function failVideoRequests(paths: readonly string[]) {
   const failure = providerError("GROK_VIDEO_REQUEST_FAILED", 502);
   fixture.allowFailure(failure);
   fixture.respond((call) => {
-    assertJsonPost(call, "http://127.0.0.1:1", paths, "Bearer dummy");
+    assertJsonPost(call, GROK_DIRECT_ORIGIN, paths, fixture.grokBearer);
     throw failure;
   });
 }
@@ -165,6 +165,7 @@ describe("062 error transport envelopes", () => {
     registerVideoRoutes(app, {
       rootDir: process.cwd(),
       packageVersion: "test",
+      grokAuthHomeDir: fixture.grokAuthHomeDir,
       config: {
         ...config,
         storage: { ...config.storage, generatedDir: TEST_DIR },
@@ -195,7 +196,8 @@ describe("062 error transport envelopes", () => {
     failVideoRequests(["/v1/videos/edits"]);
     const app = trackedApp();
     app.use(express.json());
-    registerVideoExtendedRoutes(app, { config: { storage: { generatedDir: TEST_DIR }, grokProvider: { proxyHost: "127.0.0.1", proxyPort: 1 } } });
+    registerVideoExtendedRoutes(app, { grokAuthHomeDir: fixture.grokAuthHomeDir,
+      config: { storage: { generatedDir: TEST_DIR }, grokProvider: { proxyHost: "127.0.0.1", proxyPort: 1 } } });
     try {
       await withServer(app, async (baseUrl) => {
         const response = await fixture.fetchApp(`${baseUrl}/api/video/edit`, {
@@ -223,6 +225,7 @@ describe("062 error transport envelopes", () => {
     registerVideoExtendedRoutes(app, {
       rootDir: process.cwd(),
       packageVersion: "test",
+      grokAuthHomeDir: fixture.grokAuthHomeDir,
       config: {
         ...config,
         storage: { ...config.storage, generatedDir: TEST_DIR },
@@ -254,6 +257,7 @@ describe("062 error transport envelopes", () => {
     registerVideoExtendedRoutes(app, {
       rootDir: process.cwd(),
       packageVersion: "test",
+      grokAuthHomeDir: fixture.grokAuthHomeDir,
       config: {
         ...config,
         storage: { ...config.storage, generatedDir: TEST_DIR },
@@ -288,7 +292,7 @@ describe("062 error transport envelopes", () => {
     const failure = providerError("GROK_UPSTREAM_ERROR", 502);
     fixture.allowFailure(failure);
     fixture.respond((call) => {
-      assertJsonPost(call, "http://127.0.0.1:9", ["/v1/responses", "/v1/chat/completions", "/v1/images/generations"], "Bearer dummy");
+      assertJsonPost(call, GROK_DIRECT_ORIGIN, ["/v1/responses", "/v1/chat/completions", "/v1/images/generations"], fixture.grokBearer);
       const target = call.url;
       if (target.endsWith("/v1/responses")) {
         return Response.json({ output: [{ type: "message", content: [{ type: "output_text", text: "brief" }] }] });
@@ -314,6 +318,7 @@ describe("062 error transport envelopes", () => {
           grokProvider: { ...config.grokProvider, proxyHost: "127.0.0.1", proxyPort: 9, plannerTimeoutMs: 2000, generationTimeoutMs: 2000 },
         },
         packageVersion: "test",
+        grokAuthHomeDir: fixture.grokAuthHomeDir,
       } as never, { maxImages: 1, requestId: "env-multimode" });
       assert.equal(result.images.length, 0);
       const err = result.error as { code?: string; status?: number };

--- a/tests/grok-execution-parity.test.ts
+++ b/tests/grok-execution-parity.test.ts
@@ -7,9 +7,13 @@ import type { ExecutionProgress, ImageExecutionRequest, ImageExecutionResult } f
 import { executionTestProcess } from "./_executionTestProcess.ts";
 import { openRouteHarness, type RouteCase, type Surface, type UpstreamCall } from "./_executionRouteHarness.ts";
 import { bounded } from "./_executionTrackedWrites.ts";
+import { GROK_FIXTURE_BEARER } from "./_grokAuthFixture.ts";
 
 type Lane = "grok" | "grok-api";
 const KEY = "xai-parity-original";
+/** Both lanes reach xAI directly; `grok` carries the seeded OAuth bearer, `grok-api` the key. */
+const XAI_ORIGIN = "https://api.x.ai";
+const bearerFor = (lane: Lane, key: string) => lane === "grok" ? GROK_FIXTURE_BEARER : `Bearer ${key}`;
 const ARTIFACT = "https://fixture.invalid/parity.png";
 const SOURCE_URL = "https://fixture.invalid/source.png";
 const options = { model: "grok-imagine-image", quality: "medium", size: "1024x1024",
@@ -76,8 +80,8 @@ if (executionTestProcess(import.meta.url)) describe("G05 real Grok routes and fa
         assert.equal(call.headers.get("cookie"), null);
       } else {
         assert.equal(call.method, "POST");
-        assert.equal(new URL(call.url).origin, provider === "grok" ? "http://grok-fixture.invalid" : "https://api.x.ai");
-        assert.equal(call.headers.get("authorization"), provider === "grok" ? "Bearer dummy" : `Bearer ${expectedKey}`);
+        assert.equal(new URL(call.url).origin, XAI_ORIGIN);
+        assert.equal(call.headers.get("authorization"), bearerFor(provider, expectedKey));
       }
       const changed = override?.(call);
       if (changed !== undefined) return changed;
@@ -244,21 +248,22 @@ if (executionTestProcess(import.meta.url)) describe("G05 real Grok routes and fa
   });
 
   for (const provider of ["grok", "grok-api"] as const)
-  for (const surface of ["node", "edit", "multimode"] as const)
-  for (const samePort of [false, true]) it(`G05 private artifact policy ${provider}/${surface}/samePort=${samePort}`, async () => {
-    const origin = "http://127.0.0.1:18463";
-    const artifact = `${samePort ? origin : "http://127.0.0.1:18464"}/private.png`;
-    const allowed = provider === "grok" && samePort;
-    await harness.run(surface, { context: { xaiApiKey: KEY, grokUrl: `${origin}/v1` }, upstream: (call) => {
-      if (call.method === "GET") {
-        assert.equal(allowed, true, "forbidden local artifact never reaches fake GET");
-        assert.equal(call.url, artifact);
-        assert.equal(call.headers.get("authorization"), null);
-        return new Response(Buffer.from(png, "base64"), { headers: { "content-type": "image/png" } });
-      }
-      assert.equal(new URL(call.url).origin, provider === "grok" ? origin : "https://api.x.ai");
-      assert.equal(call.headers.get("authorization"), provider === "grok" ? "Bearer dummy" : `Bearer ${KEY}`);
-      if (call.url.endsWith("/chat/completions")) return plan();
+    for (const surface of ["node", "edit", "multimode"] as const)
+      for (const samePort of [false, true]) it(`G05 private artifact policy ${provider}/${surface}/samePort=${samePort}`, async () => {
+        const origin = "http://127.0.0.1:18463";
+        const artifact = `${samePort ? origin : "http://127.0.0.1:18464"}/private.png`;
+        // No proxy hop survives the direct lane, so no loopback origin is trusted for either lane.
+        const allowed = false;
+        await harness.run(surface, { context: { xaiApiKey: KEY }, upstream: (call) => {
+          if (call.method === "GET") {
+            assert.equal(allowed, true, "forbidden local artifact never reaches fake GET");
+            assert.equal(call.url, artifact);
+            assert.equal(call.headers.get("authorization"), null);
+            return new Response(Buffer.from(png, "base64"), { headers: { "content-type": "image/png" } });
+          }
+          assert.equal(new URL(call.url).origin, XAI_ORIGIN);
+          assert.equal(call.headers.get("authorization"), bearerFor(provider, KEY));
+          if (call.url.endsWith("/chat/completions")) return plan();
       assert.match(call.url, /\/images\/(generations|edits)$/);
       return Response.json({ data: [{ url: artifact }] });
     } }, async (fixture) => {

--- a/tests/grok-planner-adapter.test.ts
+++ b/tests/grok-planner-adapter.test.ts
@@ -1,11 +1,14 @@
 import { after, afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { assertOwned, isolateExecution } from "./_executionRouteIsolation.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 const isolation = await isolateExecution();
+// These legacy adapter calls resolve the OAuth `grok` credential from ~/.progrok/auth.json.
+const grokAuth = seedGrokAuth();
 const { imageTransport } = isolation;
 const deniedFetch = globalThis.fetch;
-after(async () => { await isolation.close(); });
+after(async () => { try { await isolation.close(); } finally { grokAuth.cleanup(); } });
 afterEach(async () => {
   try {
     await imageTransport.deactivate();
@@ -54,6 +57,7 @@ function ctx(overrides: Record<string, unknown> = {}) {
       },
     },
     packageVersion: "test",
+    grokAuthHomeDir: grokAuth.homeDir,
     ...overrides,
   } as any;
 }
@@ -173,10 +177,7 @@ describe("Grok planner adapter", () => {
     }) as typeof fetch;
 
     activateImageTransport();
-    const result = await generateViaGrok("raw prompt", ctx({
-      grokActualPort: 18647,
-      grokUrl: "http://127.0.0.1:18647/v1",
-    }), {
+    const result = await generateViaGrok("raw prompt", ctx(), {
       model: "grok-imagine-image-quality",
       size: "2048x1152",
       requestId: "req_test",
@@ -185,7 +186,8 @@ describe("Grok planner adapter", () => {
 
     const searchCalls = webSearchEnabled === false ? 0 : 1;
     assert.equal(calls.length, searchCalls + 3);
-    assert.equal(calls.slice(0, searchCalls + 2).every((call) => call.url.startsWith("http://127.0.0.1:18647/")), true);
+    // Search, planner and generation all leave for the direct xAI origin.
+    assert.equal(calls.slice(0, searchCalls + 2).every((call) => call.url.startsWith("https://api.x.ai/")), true);
     assert.equal(calls.filter((call) => call.url.endsWith("/v1/responses")).length, searchCalls);
     if (searchCalls) {
       assert.equal(calls[0].url.endsWith("/v1/responses"), true);

--- a/tests/grokVideoAdapter.test.ts
+++ b/tests/grokVideoAdapter.test.ts
@@ -18,7 +18,8 @@ const { normalizeGrokVideoModel, VALID_GROK_VIDEO_MODELS } = await import("../li
 const { parsePngInfo } = await import("../lib/pngInfo.js");
 const { DEFAULT_GROK_PLANNER_MODEL } = await import("../config.js");
 const config = fixture.config;
-const PROXY = "http://video-fixture.invalid";
+/** Both lanes call xAI directly now; only the credential differs. */
+const XAI = "https://api.x.ai";
 const ARTIFACT = "https://vidgen.example/v.mp4";
 
 function ctx(overrides: Partial<RouteRuntimeContext> = {}): RouteRuntimeContext {
@@ -36,7 +37,7 @@ function ctx(overrides: Partial<RouteRuntimeContext> = {}): RouteRuntimeContext 
       },
     },
     packageVersion: "test",
-    grokUrl: PROXY,
+    grokAuthHomeDir: fixture.grokAuthHomeDir,
     ...overrides,
   };
 }
@@ -91,14 +92,13 @@ function respond(handler: (kind: RequestKind, call: UpstreamCall) => Response | 
       assert.deepEqual(headers, {});
       return handler("artifact", call);
     }
-    const origin = key ? "https://api.x.ai" : PROXY;
-    const paths: Record<string, RequestKind> = { [`${origin}/v1/responses`]: "search",
-      [`${origin}/v1/chat/completions`]: "planner", [`${origin}/v1/videos/generations`]: "start",
-      [`${origin}/v1/videos/vid-1`]: "poll" };
+    const paths: Record<string, RequestKind> = { [`${XAI}/v1/responses`]: "search",
+      [`${XAI}/v1/chat/completions`]: "planner", [`${XAI}/v1/videos/generations`]: "start",
+      [`${XAI}/v1/videos/vid-1`]: "poll" };
     assert.ok(Object.hasOwn(paths, call.url), `Unexpected video URL: ${call.url}`);
     const kind = paths[call.url];
     assert.equal(call.method, kind === "poll" ? "GET" : "POST");
-    assert.deepEqual(headers, { authorization: `Bearer ${key || "dummy"}`, "content-type": "application/json" });
+    assert.deepEqual(headers, { authorization: key ? `Bearer ${key}` : fixture.grokBearer, "content-type": "application/json" });
     if (kind === "poll") assert.equal(call.body, "");
     else { const body = JSON.parse(call.body); assert.ok(body && typeof body === "object" && !Array.isArray(body)); }
     return handler(kind, call);
@@ -379,8 +379,9 @@ const DONE_POLL = { status: "done", progress: 100, video: { url: "https://vidgen
     assert.equal(fixture.calls.length, 3);
   });
 
+  // lane=oauth resolves the seeded ~/.progrok session; lane=api-key carries an explicit key.
   for (const directKey of [undefined, "video-fixture-direct-key"]) {
-    for (const failure of ["invalid", "read-reset"] as const) it(`never regenerates on ${failure}, lane=${directKey ? "direct" : "proxy"}`, async () => {
+    for (const failure of ["invalid", "read-reset"] as const) it(`never regenerates on ${failure}, lane=${directKey ? "api-key" : "oauth"}`, async () => {
       const reset = Object.assign(new Error("fixture body reset"), { code: "ECONNRESET" });
       const stream = artifactStream([failure === "invalid" ? Buffer.from("<html>not an mp4</html>") : fakeMp4Bytes()],
         failure === "read-reset" ? { failAfterChunks: reset } : {});
@@ -389,7 +390,8 @@ const DONE_POLL = { status: "done", progress: 100, video: { url: "https://vidgen
       });
       await fixture.track(assert.rejects(generateVideoViaGrok("clip", ctx(), {
         model: "grok-imagine-video", plannedPrompt: "bounded video", duration: 1,
-        directApiKey: directKey, signal: fixture.controller().signal,
+        ...(directKey ? { credential: { kind: "api-key" as const, key: directKey } } : {}),
+        signal: fixture.controller().signal,
       }), { code: "GROK_VIDEO_DOWNLOAD_FAILED", status: 502, message: failure === "invalid"
         ? "Grok video download returned an invalid MP4 container" : "Grok video download request failed: fixture body reset" }));
       assert.deepEqual(counts, { start: 1, poll: 1, artifact: 1 });

--- a/tests/grokVideoPlannerFallback.test.ts
+++ b/tests/grokVideoPlannerFallback.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, it } from "node:test";
+import { after, afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { planGrokVideo, isDegradablePlannerFailure } from "../lib/grokVideoAdapter.js";
 import { composeFallbackVideoPrompt } from "../lib/grokVideoPlannerPrompt.js";
 import { config } from "../config.js";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 // The 260817 incident: the web-search stage succeeded and the PLANNER call stalled for its
 // whole budget, so the user lost the video. A stalled planner must now degrade to a locally
@@ -11,6 +12,10 @@ import { config } from "../config.js";
 
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
+// planGrokVideo resolves the OAuth `grok` credential first; without a seeded HOME the stub
+// fetch below would answer xAI's real token endpoint instead of the planner under test.
+const grokAuth = seedGrokAuth();
+after(() => { grokAuth.cleanup(); });
 
 function ctx(grokOverrides: Record<string, unknown> = {}) {
   return {
@@ -28,6 +33,7 @@ function ctx(grokOverrides: Record<string, unknown> = {}) {
       },
     },
     packageVersion: "test",
+    grokAuthHomeDir: grokAuth.homeDir,
   } as any; // justified: RouteRuntimeContext is a loose runtime bag; every Grok adapter test builds it this way
 }
 

--- a/tests/prompt-builder-contract.test.ts
+++ b/tests/prompt-builder-contract.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { after, afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import express from "express";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -26,6 +26,7 @@ import {
 } from "../lib/promptBuilder/router.ts";
 import { buildTransportPayload } from "../lib/promptBuilder/transport.ts";
 import { requireRuntimeContext } from "../lib/runtimeContext.ts";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 import type {
   PromptBuilderLaneSummary,
   PromptBuilderMessage,
@@ -59,6 +60,10 @@ beforeEach(() => {
   delete process.env.IMA2_PROMPT_BUILDER_BACKEND;
   delete process.env.IMA2_PROMPT_BUILDER_MODEL;
 });
+
+// The grok prompt-builder lane resolves an OAuth bearer from ~/.progrok/auth.json.
+const grokAuth = seedGrokAuth();
+after(() => { grokAuth.cleanup(); });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -259,7 +264,7 @@ function clientContext(
       promptBuilder: { backend, model },
       oauth: { ...config.oauth, generationTimeoutMs: 1_000 },
     },
-    grokUrl: "http://127.0.0.1:18645/v1",
+    grokAuthHomeDir: grokAuth.homeDir,
     oauthReadyState: "ready" as const,
     oauthReadyPromise: Promise.resolve(),
   };

--- a/tests/provider-execution-boundary.test.ts
+++ b/tests/provider-execution-boundary.test.ts
@@ -205,8 +205,8 @@ if (executionTestProcess(import.meta.url)) {
       await prepared.execute(); await prepared.execute();
       const executions = probe.calls.filter((call) => call.name !== "planGrokImage");
       assert.equal(executions.length, 2);
-      for (const call of executions) assert.equal((call.args.at(-1) as Record<string, unknown>).directApiKey,
-        surface === "classic" || surface === "node" ? "initial-invented-key" : "replacement-invented-key");
+      for (const call of executions) assert.deepEqual((call.args.at(-1) as Record<string, unknown>).credential,
+        { kind: "api-key", key: surface === "classic" || surface === "node" ? "initial-invented-key" : "replacement-invented-key" });
       probe.ctx.xaiApiKey = undefined;
       await assert.rejects(prepared.execute(), { code: "GROK_API_KEY_MISSING", status: 401 });
       assert.equal(probe.calls.filter((call) => call.name !== "planGrokImage").length, 2);

--- a/tests/provider-execution-routes.test.ts
+++ b/tests/provider-execution-routes.test.ts
@@ -6,6 +6,7 @@ import sharp from "sharp";
 import { executionTestProcess } from "./_executionTestProcess.ts";
 import { openRouteHarness, type RouteHarness, type RouteCase } from "./_executionRouteHarness.ts";
 import { bounded } from "./_executionTrackedWrites.ts";
+import { GROK_FIXTURE_BEARER } from "./_grokAuthFixture.ts";
 
 const missing = { error: "Grok API key is required for grok-api image generation", code: "GROK_API_KEY_MISSING" };
 const nai = { error: "NovelAI image generation does not accept reference images yet", code: "NAI_REF_UNSUPPORTED" };
@@ -67,8 +68,8 @@ if (executionTestProcess(import.meta.url)) {
               if (scenario === "callback-write-failure") failNextImageWrite = true;
               return new Response(Buffer.from(image, "base64"), { headers: { "content-type": "image/png" } });
             }
-            assert.equal(new URL(call.url).hostname, provider === "grok" ? "grok-fixture.invalid" : "api.x.ai");
-            assert.equal(call.headers.get("authorization"), provider === "grok" ? "Bearer dummy" : "Bearer xai-sparse-fixture");
+            assert.equal(new URL(call.url).hostname, "api.x.ai");
+            assert.equal(call.headers.get("authorization"), provider === "grok" ? GROK_FIXTURE_BEARER : "Bearer xai-sparse-fixture");
             if (call.url.endsWith("/chat/completions")) return Response.json({ choices: [{ message: { tool_calls: [{ type: "function", function: {
               name: "generate_image", arguments: JSON.stringify({ prompt: "identical planned content" }),
             } }] } }] });
@@ -173,8 +174,8 @@ if (executionTestProcess(import.meta.url)) {
     test(`${provider} positive edit reaches its concrete transport without overbroad refusal`, async () => {
       await harness.run("edit", { context: { xaiApiKey: provider === "grok-api" ? "xai-invented-fixture" : undefined }, upstream: (call) => {
         if (call.url.endsWith("/v1/images/edits")) {
-          assert.equal(call.headers.get("authorization"), provider === "grok-api" ? "Bearer xai-invented-fixture" : "Bearer dummy");
-          assert.equal(new URL(call.url).hostname, provider === "grok-api" ? "api.x.ai" : "grok-fixture.invalid");
+          assert.equal(call.headers.get("authorization"), provider === "grok-api" ? "Bearer xai-invented-fixture" : GROK_FIXTURE_BEARER);
+          assert.equal(new URL(call.url).hostname, "api.x.ai");
           return Response.json({ data: [{ url: "https://fixture.invalid/positive.png" }] });
         }
         assert.equal(call.url, "https://fixture.invalid/positive.png");

--- a/tests/provider-surface-boundary.test.ts
+++ b/tests/provider-surface-boundary.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import express from "express";
 import sharp from "sharp";
+import { seedGrokAuth } from "./_grokAuthFixture.ts";
 
 // Import config-dependent modules only after installing the owned config/DB.
 // The real fetch is reserved for the exact ephemeral app; every provider call
@@ -14,6 +15,7 @@ import sharp from "sharp";
 const nativeFetch = globalThis.fetch;
 const savedEnv = new Map<string, string | undefined>();
 let rootDir: string;
+let grokAuth: ReturnType<typeof seedGrokAuth>;
 let image: string;
 let mask: string;
 let config: typeof import("../config.ts").config;
@@ -29,6 +31,10 @@ let processCalls = 0;
 
 before(async () => {
   rootDir = await mkdtemp(join(tmpdir(), "ima2-surface-boundary-"));
+  // The grok lane is admitted only with a stored xAI session; seed one in an
+  // isolated HOME so these boundary cases reach the surface checks they target
+  // instead of stopping at 401 GROK_AUTH_REQUIRED (and never read the real ~/.progrok).
+  grokAuth = seedGrokAuth();
   for (const key of Object.keys(process.env).filter((key) => key.startsWith("IMA2_") || key === "DOTENV_CONFIG_PATH")) {
     savedEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -77,6 +83,7 @@ after(async () => {
     else process.env[key] = value;
   }
   if (rootDir) await rm(rootDir, { recursive: true, force: true });
+  grokAuth?.cleanup();
 });
 
 interface UpstreamCall { url: string; init: RequestInit }
@@ -104,6 +111,7 @@ async function withApp(fn: (fixture: Fixture) => Promise<void>, upstream?: FakeU
   const ctx = runtime.createTestRuntimeContext({
     rootDir, apiKey: "sk-fixture-only", oauthReadyState: "ready", xaiApiKey,
     oauthUrl: "http://oauth-fixture.invalid",
+    grokAuthHomeDir: grokAuth.homeDir,
     config: { ...config, storage: { ...config.storage, generatedDir } },
   });
   const app = express();

--- a/tests/video-download-cancellation.test.ts
+++ b/tests/video-download-cancellation.test.ts
@@ -5,13 +5,13 @@ import { createServer } from "node:http";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { executionTestProcess } from "./_executionTestProcess.ts";
-import { openVideoFixture, type UpstreamCall } from "./_videoExecutionFixture.ts";
+import { GROK_DIRECT_ORIGIN, openVideoFixture, type UpstreamCall } from "./_videoExecutionFixture.ts";
 import { fakeMp4Bytes, makeVideoStreamFixture } from "./_videoStreamFixture.ts";
 import { bounded } from "./_executionTrackedWrites.ts";
 import type { BusEvent } from "../lib/eventBus.ts";
 
 type Mode = "generate" | "edit" | "native" | "last-frame";
-const PROXY = "http://video-fixture.invalid";
+const PROXY = GROK_DIRECT_ORIGIN;
 const ARTIFACT = "https://video-fixture.invalid/held.mp4";
 const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=";
 
@@ -45,7 +45,7 @@ if (executionTestProcess(import.meta.url)) {
         counts.artifacts++; signal = call.signal ?? undefined; return stream.response;
       }
       assert.equal(new URL(call.url).origin, PROXY);
-      assert.equal(call.headers.get("authorization"), "Bearer dummy");
+      assert.equal(call.headers.get("authorization"), fixture.grokBearer);
       if (call.url === `${PROXY}/v1/videos/cancel-artifact`) {
         assert.equal(call.method, "GET"); counts.polls++;
         return Response.json({ status: "done", video: { url: ARTIFACT, duration: 1, respect_moderation: true } });
@@ -65,7 +65,7 @@ if (executionTestProcess(import.meta.url)) {
     const app = express(); fixture.trackApp(app); app.use(express.json());
     let response: express.Response | undefined;
     app.use((_req, res, next) => { response = res; next(); });
-    const ctx = createContext({ rootDir: fixture.root, grokUrl: PROXY,
+    const ctx = createContext({ rootDir: fixture.root, grokAuthHomeDir: fixture.grokAuthHomeDir,
       config: { ...fixture.config, storage: { ...fixture.config.storage, generatedDir: dir } } });
     if (mode === "generate") registerVideoRoutes(app, ctx);
     else registerVideoExtendedRoutes(app, ctx, { extractFrame: async () => PNG });

--- a/tests/videoExtendI2v.test.ts
+++ b/tests/videoExtendI2v.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import type { VideoExtendedDependencies } from "../routes/videoExtended.js";
 import type { BusEvent } from "../lib/eventBus.js";
 import { executionTestProcess } from "./_executionTestProcess.ts";
-import { openVideoFixture } from "./_videoExecutionFixture.ts";
+import { GROK_DIRECT_ORIGIN, openVideoFixture } from "./_videoExecutionFixture.ts";
 import { fakeMp4Bytes as fakeMp4, makeVideoStreamFixture } from "./_videoStreamFixture.ts";
 import { bounded, SettlementTimeout } from "./_executionTrackedWrites.ts";
 
@@ -65,6 +65,7 @@ async function makeApp(dir: string, dependencies: VideoExtendedDependencies = {}
   app.use(express.json());
   registerVideoExtendedRoutes(app, {
     rootDir: fixture.root, packageVersion: "test",
+    grokAuthHomeDir: fixture.grokAuthHomeDir,
     config: {
       ...config, ids: { ...config.ids, generatedHexBytes: 2 }, storage: { ...config.storage, generatedDir: dir },
       grokProvider: { ...config.grokProvider, proxyHost: "127.0.0.1", proxyPort, videoPollIntervalMs: 1, videoStartTimeoutMs: 5000, videoTimeoutMs: 30000, videoDownloadTimeoutMs: 5000, plannerTimeoutMs: 5000 },
@@ -384,8 +385,8 @@ function defaultUpstream(stream: ReturnType<typeof makeVideoStreamFixture>) {
       assert.equal(call.headers.get("authorization"), null);
       return stream.response;
     }
-    assert.equal(url.origin, "http://127.0.0.1:18645");
-    assert.equal(call.headers.get("authorization"), "Bearer dummy");
+    assert.equal(url.origin, GROK_DIRECT_ORIGIN);
+    assert.equal(call.headers.get("authorization"), fixture.grokBearer);
     if (url.pathname === "/v1/videos/real-child") {
       assert.equal(call.method, "GET"); assert.equal(call.body, "");
       return Response.json({ status: "done", video: { url: "https://artifact.fixture.invalid/child.mp4", duration: 1, respect_moderation: true } });

--- a/tests/videoExtendedRoute.test.ts
+++ b/tests/videoExtendedRoute.test.ts
@@ -5,7 +5,7 @@ import { createServer } from "node:http";
 import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { executionTestProcess } from "./_executionTestProcess.ts";
-import { openVideoFixture } from "./_videoExecutionFixture.ts";
+import { GROK_DIRECT_ORIGIN, openVideoFixture } from "./_videoExecutionFixture.ts";
 import { fakeMp4Bytes } from "./_videoStreamFixture.ts";
 
 if (executionTestProcess(import.meta.url)) {
@@ -32,16 +32,17 @@ async function listen(server: import("node:http").Server): Promise<string> {
   const origin = await fixture.listen(server, "proxy");
   fixture.bridgeProxy(server, (call) => {
     const target = new URL(call.url);
-    assert.equal(target.origin, origin);
     assert.equal(target.search, "");
     assert.equal(call.headers.get("cookie"), null);
     if (target.pathname === "/dl/out.mp4") {
+      assert.equal(target.origin, origin, "the artifact stays on the owned mock origin");
       assert.equal(call.method, "GET");
       assert.equal(call.body, "");
       assert.equal(call.headers.get("authorization"), null);
       return;
     }
-    assert.equal(call.headers.get("authorization"), "Bearer dummy");
+    assert.equal(target.origin, GROK_DIRECT_ORIGIN, "authenticated video calls leave for xAI directly");
+    assert.equal(call.headers.get("authorization"), fixture.grokBearer);
     const opts = proxyOptions.get(server)!;
     const poll = opts.operation === "extend" ? "/v1/videos/extend-1" : "/v1/videos/edit-1";
     if (target.pathname === poll) {
@@ -127,6 +128,7 @@ async function videoApp(generatedDir: string, proxyPort: number, plannerModel?: 
   registerVideoExtendedRoutes(app, {
     rootDir: fixture.root,
     packageVersion: "test",
+    grokAuthHomeDir: fixture.grokAuthHomeDir,
     config: {
       ...config,
       ids: { ...config.ids, generatedHexBytes: 2 },

--- a/tests/videoRoute.test.ts
+++ b/tests/videoRoute.test.ts
@@ -5,7 +5,7 @@ import { createServer } from "node:http";
 import { access, mkdir, mkdtemp, rm, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { executionTestProcess } from "./_executionTestProcess.ts";
-import { openVideoFixture } from "./_videoExecutionFixture.ts";
+import { GROK_DIRECT_ORIGIN, openVideoFixture } from "./_videoExecutionFixture.ts";
 import { fakeMp4Bytes } from "./_videoStreamFixture.ts";
 if (executionTestProcess(import.meta.url)) {
 type VideoFixture = Awaited<ReturnType<typeof openVideoFixture>>;
@@ -32,16 +32,17 @@ async function listen(server: import("node:http").Server): Promise<string> {
   const origin = await fixture.listen(server, "proxy");
   fixture.bridgeProxy(server, (call) => {
     const target = new URL(call.url);
-    assert.equal(target.origin, origin);
     assert.equal(target.search, "");
     assert.equal(call.headers.get("cookie"), null);
     if (target.pathname === "/dl/v.mp4") {
+      assert.equal(target.origin, origin, "the artifact stays on the owned mock origin");
       assert.equal(call.method, "GET");
       assert.equal(call.body, "");
       assert.equal(call.headers.get("authorization"), null);
       return;
     }
-    assert.equal(call.headers.get("authorization"), "Bearer dummy");
+    assert.equal(target.origin, GROK_DIRECT_ORIGIN, "authenticated video calls leave for xAI directly");
+    assert.equal(call.headers.get("authorization"), fixture.grokBearer);
     if (target.pathname === "/v1/videos/vid-xyz") {
       assert.equal(call.method, "GET");
       assert.equal(call.body, "");
@@ -120,6 +121,7 @@ async function videoApp(generatedDir, proxyPort) {
   registerVideoRoutes(app, {
     rootDir: fixture.root,
     packageVersion: "test",
+    grokAuthHomeDir: fixture.grokAuthHomeDir,
     config: {
       ...config,
       storage: { ...config.storage, generatedDir },


### PR DESCRIPTION
The `grok` lane now calls `https://api.x.ai` directly with the xAI OAuth session from `~/.progrok/auth.json`; the bundled progrok proxy is no longer on any request path. Layer 3 of the stack described in #233; builds on #234.

**Before:** `grok` requests went to `127.0.0.1:18645` with `Authorization: Bearer dummy` and progrok swapped in the real token; `grok-api` already went direct. Three `videoExtended` routes always used the proxy even for `grok-api` users.
**After:** one transport in `lib/grokRuntime.ts`. `getGrokEndpoint(path, credential)` always builds the api.x.ai URL; `resolveGrokCredential(ctx, lane)` is the only place a lane becomes a bearer (api key or OAuth token, refreshing when within 120s of expiry); `fetchWithGrokAuth` refreshes exactly once on a 401 and replays, sitting outside `grokFetchWithRetry` so the leaf retrier never sees credentials. Every image/multimode/node/edit/planner/prompt-builder/video call resolves a credential up front and carries it through the request, so a job never mixes bearers or refreshes more than once. Admission is symmetric: `grok` without a stored session is 401 `GROK_AUTH_REQUIRED`. `/api/grok/status` keeps its four status literals; `offline` now means `login_required`.

A behavior change reviewers should see: the proxy-origin exception in the artifact download policy is gone with the proxy, so loopback artifact URLs are rejected for both lanes (`tests/grok-execution-parity.test.ts` G05).

**Validation.** `npm test`: 3546 tests, 3543 pass, 0 fail (17s; previously grok-lane tests read the developer's real auth file and hit auth.x.ai, now they seed an isolated HOME). typecheck + typecheck:tests exit 0. Live probe with an expired real session copied into a temp HOME: three concurrent `getGrokAccessToken` calls produced one `POST auth.x.ai/oauth2/token`, the refresh token rotated, file stayed 0600, and `GET api.x.ai/v1/models` returned 200 with all five `grok-imagine*` models (`devlog/_plan/260909_grok_native_oauth/evidence/wp3-live-refresh.txt`).

`lib/grokProxyLauncher.ts` and the proxy config keys still exist but have no request-path callers; layer 4 removes them.

**Stack** (merge bottom-up):
| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 5 | (next) | SoT docs, i18n, archive | docs consistency |
| 4 | (next) | remove progrok, native CLI, readiness | packaging, CI smoke |
| 3 | this | grok lane direct api.x.ai ← you are here | credential resolution, 401 hook |
| 2 | #234 | lib/xaiAuth.ts | token store, refresh, negative cases |
| 1 | #233 | roadmap | plan soundness only |

Depends on #234. Review this PR's diff only.
