### PR TITLE
docs(release): record the v3.16.0 release receipt

### DIFF
--- a/devlog/_plan/260909_grok_native_oauth/070_release_v3160.md
+++ b/devlog/_plan/260909_grok_native_oauth/070_release_v3160.md
@@ -1,0 +1,71 @@
+---
+created: 2026-09-09
+updated: 2026-09-09
+tags: [ima2-gen, devlog, grok, xai, oauth, release, v3.16.0, receipt]
+---
+
+# 070 — v3.16.0 릴리스 영수증
+
+Grok 레인의 progrok 프록시 제거가 v3.16.0으로 배포됐다. 릴리스 커밋은
+`7fa7d426d92813caeeff667a458b781237029df0` ("[agent] chore: release v3.16.0")이고,
+`main` / `dev` / `preview` / `v3.16.0` 태그가 전부 이 하나의 SHA를 가리킨다.
+
+## 머지 경로
+
+스택은 아래에서 위로 순서대로 dev에 들어갔다. 각 머지는 리뷰된 head SHA를
+`--match-head-commit`으로 고정했고, 하위가 머지되면 GitHub이 다음 PR의 base를
+dev로 자동 재타겟했다.
+
+| PR | 머지 커밋 | 내용 |
+|---|---|---|
+| #233 | c1c11525 | 로드맵 유닛 |
+| #234 | a9873e7b | `lib/xaiAuth.ts` |
+| #235 | f56c72f5 | grok 레인 api.x.ai 직접 호출 |
+| #236 | 44d51c04 | progrok 제거, 네이티브 CLI, readiness |
+| #237 | d889acd9 | SoT·문서·i18n |
+
+`git diff 55b3d77a..origin/dev`가 비어 있어 머지된 트렁크가 리뷰된 트리를 그대로
+담고 있음을 확인했다. 이어서 승격 PR #238(dev→main)과, 릴리스 직전 기록인
+#239(CodeQL 107 dismissal + 3.16.0 changelog 제목) 및 그 승격 #240이 들어갔다.
+
+## 릴리스 실행
+
+`release.yml` run `34304218927`, `bump=minor`, `dry_run=false`,
+`expected_sha=4b2349e8`. minor인 이유는 번들 의존성 하나, config 키 7개,
+CLI 서브커맨드 2개가 사라진 사용자 표면 변경이기 때문이다.
+
+워크플로가 소유한 순서대로 진행됐다.
+
+1. 버전 커밋 7fa7d426 생성 + `verify:release`
+2. 후보 CI `34304673924` — 6/6 success (ubuntu node22/24, windows node22/24, macOS 설치, frontend e2e)
+3. main/preview 이동 후 preview publish `34305686185` — `3.16.0-preview.260909.34305686185.1`, gitHead 7fa7d426
+4. `npm-stable` 환경 게이트 승인 (태그 잡, 이어서 stable publish 잡)
+5. stable publish `34307228141` — npm `latest` 3.16.0, GitHub Release 생성
+
+앞선 두 번의 시도는 후보 CI의 windows node22 레인에서 이 릴리스와 무관한 플레이크로
+실패했다. 첫 번째(`34300502405`)는 `mcp-job-envelope-consumer`의 20초 클라이언트
+타임아웃이 느린 러너에서 먼저 터진 것이고, 두 번째(`34302358198`)는 임시 sqlite
+파일 unlink의 `EBUSY`였다. 두 경우 모두 후보 ref가 정리되고 main·태그·npm은
+움직이지 않았다.
+
+## 배포 증거
+
+```
+npm view ima2-gen@latest version   -> 3.16.0
+npm view ima2-gen@latest gitHead   -> 7fa7d426d92813caeeff667a458b781237029df0
+npm dist-tags: latest 3.16.0, preview 3.16.0-preview.260909.34305686185.1
+git rev-parse origin/main origin/dev origin/preview v3.16.0^{commit}
+  -> 7fa7d426d92813caeeff667a458b781237029df0 (모두 동일)
+gh release view v3.16.0 -> draft=false, assets: release-manifest.json, sbom.cdx.json
+npm audit signatures -> 37 packages have verified attestations
+```
+
+릴리스 커밋에서 전체 스위트를 다시 돌려 3534개 중 3531 pass, 3 skip, 0 fail을
+확인했다. Pages는 `pages.yml`을 `release_version=3.16.0`,
+`release_sha=7fa7d426...`로 dispatch해 배포했다.
+
+## 남은 것
+
+xAI가 OAuth의 api.x.ai 접근을 `/v1/me` 외에는 문서화하지 않는다는 위험은 README와
+structure/06에 남아 있다. 경로가 닫히면 `grok-api`(API 키)가 문서화된 대안이다.
+OpenCodex 쪽 결함 4건(lidge-jun/opencodex#4045~#4048)은 업스트림 처리 대기 중이다.

--- a/devlog/_plan/README.md
+++ b/devlog/_plan/README.md
@@ -25,7 +25,7 @@ Deferred / 미래 항목은 `_plan/` 직속이 아니라 `_plan/_future/`에 둔
 | 경로 | 상태 |
 |---|---|
 | `260908_xai_imagine_spec_resync/` | v3.15.1로 배포 완료. xAI ref2v 상한 7->14, 모델별 ref2v 길이, 연장 1-15s, 이미지 편집 5장, 날짜 별칭, 오디오 단독 ref2v를 서버·UI·CLI·문서에 반영. GUI에 보이스 선택과 영상 편집 버튼 추가. 남은 것: 컴포저 드롭에서 편집으로 들어가는 흐름(결과 카드로 대체 가능). 배포 기록은 070_release_v3151.md. |
-| `260909_grok_native_oauth/` | wp1~wp5 구현 완료, PR #233~#237 스택(base dev) 오픈. progrok 자식 프로세스 프록시 제거, grok 레인이 `~/.progrok/auth.json` xAI OAuth 세션으로 api.x.ai 직접 호출, `ima2 grok login/status/logout` 네이티브. 남은 것: 스택 머지, v3.16 릴리스. |
+| `260909_grok_native_oauth/` | v3.16.0으로 배포 완료. PR #233~#237 스택이 dev에 머지되고 #238/#240으로 main 승격, 릴리스 커밋 7fa7d426. progrok 프록시 제거, grok 레인이 xAI OAuth 세션으로 api.x.ai 직접 호출, `ima2 grok login/status/logout` 네이티브. 영수증은 070_release_v3160.md. |
 
 ## 일정이 있는 후속 항목
 

--- a/structure/07-devlog-map.md
+++ b/structure/07-devlog-map.md
@@ -124,7 +124,7 @@ is empty again; GitHub parity and CI receipts live in the archived closeout.
 
 | Unit | Status | Open issue |
 |---|---|---|
-| `260909_grok_native_oauth/` | wp1-wp5 implemented; PR stack #233-#237 open against dev. progrok proxy removed, grok lane calls api.x.ai with the stored xAI OAuth session, native `ima2 grok` CLI. Remaining: merge and the v3.16 release. | — |
+| `260909_grok_native_oauth/` | Shipped in v3.16.0 (release commit 7fa7d426). progrok proxy removed; the grok lane calls api.x.ai with the stored xAI OAuth session and `ima2 grok` is native. Receipt: 070_release_v3160.md. | — |
 | `260902_studio_surfaces/` | NovelAI dual-prompt UI, configurable Prompt Builder backend, Canvas vectorize entry, docs upgrade, and release train. | — |
 
 Open issue #150 (Provider Adapter v1 RFC) is tracked in `_plan/README.md` but


### PR DESCRIPTION
Records the v3.16.0 release for the Grok native xAI OAuth unit and updates the plan hub and devlog map to say it shipped.

The release commit is `7fa7d426`, and `main`, `dev`, `preview` and the `v3.16.0` tag all resolve to it. npm `latest` is 3.16.0 with a `gitHead` matching the tag, the GitHub Release carries `release-manifest.json` and `sbom.cdx.json`, and `npm audit signatures` verifies the attestations. The receipt also documents the two earlier release attempts that failed on the Windows node-22 candidate lane for reasons unrelated to this content — an `mcp-job-envelope-consumer` client timeout and an `EBUSY` unlinking a temp SQLite file — neither of which moved `main`, a tag, or npm.
